### PR TITLE
feat: truncate long institution name

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -100,6 +100,7 @@ export default async function SearchResultPage({
       className={cn(
         "w-full",
         "lg:w-[60%]",
+        "sm:w-[80%]",
         `min-h-[90svh]`,
         "flex",
         "flex-col",

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -30,9 +30,11 @@ export function UserCard({ user }: { user: User }) {
       </Flex>
       <Flex className="items-center gap-x-1">
         {user.affiliation ? (
-          <Flex className="items-center gap-x-1 text-gray-11">
+          <Flex className="items-center gap-x-1 text-gray-11 overflow-hidden">
             <HomeIcon width="16" height="16" />
-            <Text size="1">{user.affiliation}</Text>
+            <Text size="1" className="truncate">
+              {user.affiliation}
+            </Text>
             <Text size="1" className="ml-[6px]">
               /
             </Text>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fix issue #142.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #142 

## Notes

<!-- Other thing to say -->

Fixed the issue by:
1. Adjusting the width of the page.
2. Truncate the text if the institution name is really long. 

We will try our best to adjust the width of `/search` page to fit the institution name. 
But, sorry we must truncate if that's really long in `/search` page. Since we don't set the limit of characters to the institution name, no matter how hard we adjust the width of the page (or the card), the edge case will still happen.

Preview link: https://rec-net-git-fix-long-institution-name-recnet-542617e7.vercel.app/

## TODO

- [x] Paste the testing link


