### PR TITLE
Fix get Upcoming Rec bug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/apps/recnet/src/server/routers/rec.ts
+++ b/apps/recnet/src/server/routers/rec.ts
@@ -65,6 +65,17 @@ export const recRouter = router({
             rec: null,
           };
         }
+        // check if the rec is for the current cycle
+        const cutOff = getNextCutOff();
+        if (
+          getDateFromFirebaseTimestamp(postData.cutoff).getTime() !==
+          cutOff.getTime()
+        ) {
+          return {
+            rec: null,
+          };
+        }
+
         const userPreviewData = userPreviewSchema.parse({
           id: user.seed,
           handle: user.username,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix get Upcoming Rec bug. Add cutoff validation step to the query logic to prevent getting rec not in this cycle.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://cornellnlp.slack.com/archives/C061LJ5BT3J/p1711212205295569

## Notes

<!-- Other thing to say -->

## TODO

- [x] Paste the testing link: https://rec-net-git-fix-getupcomingrec-recnet-542617e7.vercel.app/
- [x] Clear `console.log` or `console.error` for debug usage
