### PR TITLE
Fix: coerce api params

### DIFF
--- a/libs/recnet-api-model/src/lib/api/admin.ts
+++ b/libs/recnet-api-model/src/lib/api/admin.ts
@@ -13,9 +13,9 @@ export type GetStatsResponse = z.infer<typeof getStatsResponseSchema>;
 
 // GET /inviteCodes
 export const getInviteCodesParamsSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
-  used: z.boolean().optional(),
+  page: z.coerce.number(),
+  pageSize: z.coerce.number(),
+  used: z.coerce.boolean().optional(),
 });
 export type GetInviteCodesParams = z.infer<typeof getInviteCodesParamsSchema>;
 

--- a/libs/recnet-api-model/src/lib/api/rec.ts
+++ b/libs/recnet-api-model/src/lib/api/rec.ts
@@ -21,8 +21,8 @@ export type RecFormSubmission = z.infer<typeof recFormSubmissionSchema>;
 
 // GET /recs
 export const getRecsParamsSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
+  page: z.coerce.number(),
+  pageSize: z.coerce.number(),
   userId: z.string(),
 });
 export type GetRecsParams = z.infer<typeof getRecsParamsSchema>;
@@ -35,9 +35,9 @@ export type GetRecsResponse = z.infer<typeof getRecsResponseSchema>;
 
 // GET /recs/feeds
 export const getRecsFeedsParamsSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
-  cutoff: z.number(), // timestamp
+  page: z.coerce.number(),
+  pageSize: z.coerce.number(),
+  cutoff: z.coerce.number(), // timestamp
 });
 export type GetRecsFeedsParams = z.infer<typeof getRecsFeedsParamsSchema>;
 

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -4,8 +4,8 @@ import { userPreviewSchema, userSchema } from "../model";
 
 // GET /users
 export const getUsersParamsSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
+  page: z.coerce.number(),
+  pageSize: z.coerce.number(),
   handle: z.string().optional(),
   keyword: z.string().optional(),
   id: z.string().optional(),
@@ -31,8 +31,8 @@ export const getUserMeResponseSchema = z.object({
 export type GetUserMeResponse = z.infer<typeof getUserMeResponseSchema>;
 
 // PATCH /users/me
-export const patchUserMeParamsSchema = userSchema.partial();
-export type PatchUserMeParams = z.infer<typeof patchUserMeParamsSchema>;
+export const patchUserMeRequestSchema = userSchema.partial();
+export type PatchUserMeRequest = z.infer<typeof patchUserMeRequestSchema>;
 
 export const patchUserMeResponseSchema = z.object({
   user: userSchema,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Since params are just strings initially, if we did not add `coerce` to the schema, it will cause `recnet-api` throw error when parsing params.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
Please merge this fix to the API branches you are working on right now after merge into `master`.

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
