### PR TITLE
Add authorization guard

### DIFF
--- a/apps/recnet-api/src/utils/getJWTPayloadFromReq.ts
+++ b/apps/recnet-api/src/utils/getJWTPayloadFromReq.ts
@@ -1,4 +1,5 @@
 import { HttpStatus } from "@nestjs/common";
+import { Request } from "express";
 import { z } from "zod";
 
 import { recnetJwtPayloadSchema } from "@recnet/recnet-jwt";

--- a/apps/recnet-api/src/utils/getJWTPayloadFromReq.ts
+++ b/apps/recnet-api/src/utils/getJWTPayloadFromReq.ts
@@ -1,0 +1,24 @@
+import { HttpStatus } from "@nestjs/common";
+import { z } from "zod";
+
+import { recnetJwtPayloadSchema } from "@recnet/recnet-jwt";
+
+import { RecnetError } from "./error/recnet.error";
+import { ErrorCode } from "./error/recnet.error.const";
+
+const reqWithRecnetJwtPayload = z.object({
+  jwtPayload: recnetJwtPayloadSchema,
+});
+
+export function getRecnetJWTPayloadFromReq(req: Request) {
+  const parsedRes = reqWithRecnetJwtPayload.safeParse(req);
+  if (parsedRes.success) {
+    return parsedRes.data.jwtPayload;
+  } else {
+    throw new RecnetError(
+      ErrorCode.ZOD_VALIDATION_ERROR,
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "Error parsing jwt payload from request."
+    );
+  }
+}

--- a/apps/recnet-api/src/utils/guards/auth.guard.ts
+++ b/apps/recnet-api/src/utils/guards/auth.guard.ts
@@ -1,0 +1,45 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  mixin,
+} from "@nestjs/common";
+import { Request } from "express";
+
+import {
+  verifyFirebaseJwt,
+  verifyRecnetJwt,
+  getPublicKey,
+} from "@recnet/recnet-jwt";
+
+export const AuthGuard = (jwtType: "FirebaseJWT" | "RecNetJWT") => {
+  class RoleGuardMixin implements CanActivate {
+    async canActivate(context: ExecutionContext) {
+      const request = context.switchToHttp().getRequest();
+      const token = this.extractTokenFromHeader(request);
+      if (!token) {
+        throw new UnauthorizedException();
+      }
+      try {
+        const publicKey = await getPublicKey(token);
+        if (jwtType === "FirebaseJWT") {
+          verifyFirebaseJwt(token, publicKey);
+        } else {
+          verifyRecnetJwt(token, publicKey);
+        }
+      } catch (error) {
+        throw new UnauthorizedException();
+      }
+      return true;
+    }
+
+    private extractTokenFromHeader(request: Request): string | undefined {
+      const [type, token] = request.headers.authorization?.split(" ") ?? [];
+      return type === "Bearer" ? token : undefined;
+    }
+  }
+
+  const guard = mixin(RoleGuardMixin);
+  return guard;
+};

--- a/apps/recnet-api/src/utils/guards/auth.guard.ts
+++ b/apps/recnet-api/src/utils/guards/auth.guard.ts
@@ -13,7 +13,9 @@ import {
   getPublicKey,
 } from "@recnet/recnet-jwt";
 
-export const AuthGuard = (jwtType: "FirebaseJWT" | "RecNetJWT") => {
+import { JWTType } from "./token.type";
+
+export const AuthGuard = (jwtType: JWTType) => {
   class RoleGuardMixin implements CanActivate {
     async canActivate(context: ExecutionContext) {
       const request = context.switchToHttp().getRequest();
@@ -24,9 +26,11 @@ export const AuthGuard = (jwtType: "FirebaseJWT" | "RecNetJWT") => {
       try {
         const publicKey = await getPublicKey(token);
         if (jwtType === "FirebaseJWT") {
-          verifyFirebaseJwt(token, publicKey);
+          const payload = verifyFirebaseJwt(token, publicKey);
+          request.jwtPayload = payload;
         } else {
-          verifyRecnetJwt(token, publicKey);
+          const payload = verifyRecnetJwt(token, publicKey);
+          request.jwtPayload = payload;
         }
       } catch (error) {
         throw new UnauthorizedException();

--- a/apps/recnet-api/src/utils/guards/token.type.ts
+++ b/apps/recnet-api/src/utils/guards/token.type.ts
@@ -1,0 +1,1 @@
+export type JWTType = "FirebaseJWT" | "RecNetJWT";

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/jest": "^29.4.0",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash.groupby": "^4.6.9",
-    "@types/node": "^20",
+    "@types/node": "^20.11.30",
     "@types/react": "^18.2.67",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^6.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.3.4
@@ -171,37 +167,37 @@ devDependencies:
     version: 10.0.2(@nestjs/common@10.0.2)(@nestjs/core@10.0.2)(@nestjs/platform-express@10.0.2)
   '@nx/cypress':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
   '@nx/eslint':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
   '@nx/eslint-plugin':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
   '@nx/jest':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
   '@nx/js':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
   '@nx/nest':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
   '@nx/next':
     specifier: 18.0.4
-    version: 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
+    version: 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
   '@nx/node':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
   '@nx/vite':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
   '@nx/web':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
   '@nx/webpack':
     specifier: 18.0.4
-    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
+    version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
   '@nx/workspace':
     specifier: 18.0.4
     version: 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)
@@ -230,8 +226,8 @@ devDependencies:
     specifier: ^4.6.9
     version: 4.6.9
   '@types/node':
-    specifier: ^20
-    version: 20.0.0
+    specifier: ^20.11.30
+    version: 20.11.30
   '@types/react':
     specifier: ^18.2.67
     version: 18.2.67
@@ -294,7 +290,7 @@ devDependencies:
     version: 9.0.2
   jest:
     specifier: ^29.4.1
-    version: 29.4.1(@types/node@20.0.0)(ts-node@10.9.1)
+    version: 29.4.1(@types/node@20.11.30)(ts-node@10.9.1)
   jest-environment-jsdom:
     specifier: ^29.4.1
     version: 29.4.1
@@ -324,19 +320,19 @@ devDependencies:
     version: 29.1.0(@babel/core@7.24.3)(babel-jest@29.4.1)(jest@29.4.1)(typescript@5.3.2)
   ts-node:
     specifier: 10.9.1
-    version: 10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2)
+    version: 10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2)
   typescript:
     specifier: ~5.3.2
     version: 5.3.2
   vite:
     specifier: ~5.0.0
-    version: 5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
+    version: 5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
   vite-plugin-dts:
     specifier: ~2.3.0
-    version: 2.3.0(@types/node@20.0.0)(vite@5.0.0)
+    version: 2.3.0(@types/node@20.11.30)(vite@5.0.0)
   vitest:
     specifier: ^1.0.4
-    version: 1.0.4(@types/node@20.0.0)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
+    version: 1.0.4(@types/node@20.11.30)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
   webpack-cli:
     specifier: ^5.1.4
     version: 5.1.4(webpack@5.91.0)
@@ -1960,7 +1956,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/aix-ppc64@0.19.12:
@@ -1978,7 +1973,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm64@0.19.12:
@@ -1996,7 +1990,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.19.12:
@@ -2014,7 +2007,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.19.12:
@@ -2032,7 +2024,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.19.12:
@@ -2050,7 +2041,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.19.12:
@@ -2068,7 +2058,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.12:
@@ -2086,7 +2075,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.19.12:
@@ -2104,7 +2092,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.19.12:
@@ -2122,7 +2109,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.19.12:
@@ -2140,7 +2126,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.19.12:
@@ -2158,7 +2143,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.19.12:
@@ -2176,7 +2160,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.19.12:
@@ -2194,7 +2177,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.19.12:
@@ -2212,7 +2194,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.19.12:
@@ -2230,7 +2211,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.19.12:
@@ -2248,7 +2228,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.19.12:
@@ -2266,7 +2245,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.19.12:
@@ -2284,7 +2262,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.19.12:
@@ -2302,7 +2279,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.19.12:
@@ -2320,7 +2296,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.19.12:
@@ -2338,7 +2313,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.19.12:
@@ -2356,7 +2330,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.19.12:
@@ -3101,14 +3074,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3136,7 +3109,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       jest-mock: 29.7.0
     dev: true
 
@@ -3163,7 +3136,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3196,7 +3169,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3284,7 +3257,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       '@types/yargs': 17.0.32
       chalk: 4.1.2
     dev: true
@@ -3360,27 +3333,27 @@ packages:
       read-yaml-file: 1.1.0
     dev: false
 
-  /@microsoft/api-extractor-model@7.28.13(@types/node@20.0.0):
+  /@microsoft/api-extractor-model@7.28.13(@types/node@20.11.30):
     resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.0.0)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.30)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.43.0(@types/node@20.0.0):
+  /@microsoft/api-extractor@7.43.0(@types/node@20.11.30):
     resolution: {integrity: sha512-GFhTcJpB+MI6FhvXEI9b2K0snulNLWHqC/BbcJtyNYcKUiw7l3Lgis5ApsYncJ0leALX7/of4XfmXk+maT111w==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.0.0)
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.11.30)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.0.0)
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.30)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0(@types/node@20.0.0)
-      '@rushstack/ts-command-line': 4.19.1(@types/node@20.0.0)
+      '@rushstack/terminal': 0.10.0(@types/node@20.11.30)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@20.11.30)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -3771,10 +3744,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  /@nrwl/cypress@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nrwl/cypress@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-X7ZORP9Xt3lB+7goAb5JcBfVl6FQx8BPNv6TFi9ZiKayUqovgCMPOlmL2BDizsladv+7iacnTZTdo2X/4aunJA==}
     dependencies:
-      '@nx/cypress': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/cypress': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3798,10 +3771,10 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/eslint-plugin-nx@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nrwl/eslint-plugin-nx@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-j+5d7+ANY4E7Xn0CUXi+U8DRtv1WKYfI5dxL8JF5EPAfRl7xcX9VVPA9/R5dc/PHXIPeJMIg2CEH1TetH7O6Vw==}
     dependencies:
-      '@nx/eslint-plugin': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/eslint-plugin': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3818,10 +3791,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/jest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nrwl/jest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-oe4qfnXc1WUPPmd9ua4mtgiqwXY+2XPz6zSkWghrrvc5wXu15tPvrBxHeU+KEXWu+rVy3iGLU2s5AivdXxEbIA==}
     dependencies:
-      '@nx/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nx/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3838,10 +3811,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/js@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nrwl/js@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-7aY6vjHHD99MMF+WtHSdmA7sxLmMNhbd12CQ6lXmSK41Yj82mBgQMwV/Ed+UT10XEh5uMes/iODL460SzwPMZA==}
     dependencies:
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3855,10 +3828,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/nest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nrwl/nest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-tLlHOhV/8fFf5IhYyXekF4y7xVvbM5gK+IGKUTVQKZW2GMSXO3DQmjQyrUEzuEk9O/WAujhXsHURd4fX06+zVg==}
     dependencies:
-      '@nx/nest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nx/nest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3877,10 +3850,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/next@18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0):
+  /@nrwl/next@18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0):
     resolution: {integrity: sha512-61eOkxc219pfmIVOaIRJXBhQTuclGeFdL9SYzr1TBPp2gZXoLvY+9NEsw3UdQ13rkNAC/FgY8E0TYmog6MWESw==}
     dependencies:
-      '@nx/next': 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@nx/next': 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -3915,10 +3888,10 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nrwl/node@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nrwl/node@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-e7kpWUazYmiiFUTdzvOUeSMukolS0TEgfEqFdPjb+L3QaN58KdrsBAiMlY1GVX2VR019nJKBJXGXn6LOYfDxUg==}
     dependencies:
-      '@nx/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nx/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3936,10 +3909,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/react@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nrwl/react@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-2hx7DpKFp+ao8l8H9aOC/ZlVC0/b3w+xCx3u0pN4LatkFvSvTiy7zV0kL9oi+FZM48Gxnm4nQf8qP4q8bT2G8g==}
     dependencies:
-      '@nx/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3966,10 +3939,10 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/vite@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4):
+  /@nrwl/vite@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4):
     resolution: {integrity: sha512-9fmyTxQFSYQGvgK8C5KuPeRbX0kpQgQAdmrvgv0QwqZZyHCaduFMUpUyBpC+yHq4BzGQqxvPTfIR5as59d8+xg==}
     dependencies:
-      '@nx/vite': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
+      '@nx/vite': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3985,10 +3958,10 @@ packages:
       - vitest
     dev: true
 
-  /@nrwl/web@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nrwl/web@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-NJSWj4pH/CWCFj3liOg3ExskfWqynjpGNsPS7zmkM6isbFHRXx7+s+eAVIQJtk5AttKOGeCUkUAaA91SaaTxKg==}
     dependencies:
-      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4002,10 +3975,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/webpack@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4):
+  /@nrwl/webpack@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-5GP8leMQHjyvEEflkuOGIDZhZ3kteYME0sKSAmpdD7jMnR9D1OLpRbq0V2WbyhMCCCuC6ae0ihzGZy8n8VhmuQ==}
     dependencies:
-      '@nx/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
+      '@nx/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -4056,7 +4029,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@nx/cypress@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nx/cypress@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-G/t83/SSYNIor8aGE+u9nNbCrqcsbG4EnhESP0eXwk5k6ycW6eVGMuSlLkRe7debosL/RhGLwcw491alQug7PQ==}
     peerDependencies:
       cypress: '>= 3 < 14'
@@ -4064,10 +4037,10 @@ packages:
       cypress:
         optional: true
     dependencies:
-      '@nrwl/cypress': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nrwl/cypress': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
       detect-port: 1.5.1
       semver: 7.6.0
@@ -4102,7 +4075,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /@nx/eslint-plugin@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nx/eslint-plugin@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-9QdhPO7r8tv6edInHzLSvimOxshZ5swkooqf/K/83RJ+2KfN/GLEIbLWx59xcqyYxc0D0W7y2XbhjL4XZJZPbw==}
     peerDependencies:
       '@typescript-eslint/parser': ^6.13.2
@@ -4111,9 +4084,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@nrwl/eslint-plugin-nx': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nrwl/eslint-plugin-nx': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(@typescript-eslint/parser@6.13.2)(eslint-config-prettier@9.1.0)(eslint@8.48.0)(nx@18.0.4)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@typescript-eslint/parser': 6.13.2(eslint@8.48.0)(typescript@5.3.2)
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.48.0)(typescript@5.3.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.48.0)(typescript@5.3.2)
@@ -4137,7 +4110,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/eslint@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4):
+  /@nx/eslint@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4):
     resolution: {integrity: sha512-6mjtPjXkS0aUWfF17D+PZI+Hhn+Cvm2yWTiDoVANsqt9rTOmlCa4fr01OcSyuaWFtkUlbKiKdQ1YYFyLD8zm7A==}
     peerDependencies:
       js-yaml: 4.1.0
@@ -4146,8 +4119,8 @@ packages:
         optional: true
     dependencies:
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/linter': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/linter': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
       eslint: 8.48.0
       tslib: 2.3.0
       typescript: 5.3.2
@@ -4163,18 +4136,18 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/jest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nx/jest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-A114oLtWCK99CaY/hUR00/1RISf77jqEgduDFsiaoe8fpr74HN3E8Z/NWW6gG9rkB8ymnvJMJGfbrN+2/Vv75Q==}
     dependencies:
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@nrwl/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nrwl/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
       chalk: 4.1.2
       identity-obj-proxy: 3.0.0
-      jest-config: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
       jest-resolve: 29.7.0
       jest-util: 29.7.0
       minimatch: 9.0.3
@@ -4196,7 +4169,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/js@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nx/js@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-ma8QMTHZm0LzGYZ1xdVfSUONKb1S5qbiI1DHxhztrsSo3jARZfSAMKM3Bm7ag9MBitpDsoUlgy7JCPmGCAcxAw==}
     peerDependencies:
       verdaccio: ^5.0.4
@@ -4211,7 +4184,7 @@ packages:
       '@babel/preset-env': 7.24.3(@babel/core@7.24.3)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.3)
       '@babel/runtime': 7.24.1
-      '@nrwl/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nrwl/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
       '@nx/workspace': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
@@ -4231,7 +4204,7 @@ packages:
       ora: 5.3.0
       semver: 7.6.0
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2)
       tsconfig-paths: 4.2.0
       tslib: 2.3.0
     transitivePeerDependencies:
@@ -4246,10 +4219,10 @@ packages:
       - typescript
     dev: true
 
-  /@nx/linter@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4):
+  /@nx/linter@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4):
     resolution: {integrity: sha512-yCg7H63eWkjReQUagAFAoICD53ByYZDyRqlkarZe9AGRWJM4GYKhJntihsk1mUOO7Sz0a907BMaWk8Wn5HbHEA==}
     dependencies:
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4263,15 +4236,15 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/nest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nx/nest@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-6rUZhDD+q7TYrITphQTovT4YPa5wPpWdnE62A5+FEF+w5Yj4/5w01jNFrH2p/Ix1relfEUP7+vulCb7hxRNLFg==}
     dependencies:
       '@nestjs/schematics': 9.2.0(typescript@5.3.2)
-      '@nrwl/nest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nrwl/nest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
       tslib: 2.3.0
     transitivePeerDependencies:
@@ -4292,19 +4265,19 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/next@18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0):
+  /@nx/next@18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0):
     resolution: {integrity: sha512-at+5JsRQ+/FrWhJn6cczuU3OecTwcF61fMpfyTewRv9+hYZspB7ISKLLhCGFpyIngYnysueAxGJY0JdbjqZB0A==}
     peerDependencies:
       next: '>=14.0.0'
     dependencies:
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.3)
-      '@nrwl/next': 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
+      '@nrwl/next': 18.0.4(@babel/core@7.24.3)(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(next@14.1.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)(webpack@5.91.0)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
       '@nx/workspace': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)
       '@svgr/webpack': 8.1.0(typescript@5.3.2)
       chalk: 4.1.2
@@ -4349,14 +4322,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nx/node@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
+  /@nx/node@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2):
     resolution: {integrity: sha512-syjRRex+QuNTnDkIBG4z4Osu7vC5eYeb/nBZX6zmo/4H8y//tbBEjYRV2Yw4wpQp/gCA6fc+WFB9JkdfrMOwrA==}
     dependencies:
-      '@nrwl/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nrwl/node': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
-      '@nx/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
+      '@nx/jest': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(ts-node@10.9.1)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       tslib: 2.3.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -4465,14 +4438,14 @@ packages:
     dev: true
     optional: true
 
-  /@nx/react@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nx/react@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-a67oULoXM0wWpTt4Tf3oJZY4CU1N2AEz5LVHE8LaKXwBi8gzbCSxVAVyeON3Jv1hNR6tmRdWFq7HuKnmKSR5rw==}
     dependencies:
-      '@nrwl/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nrwl/react': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
-      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/eslint': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
       '@svgr/webpack': 8.1.0(typescript@5.3.2)
       chalk: 4.1.2
@@ -4492,21 +4465,21 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/vite@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4):
+  /@nx/vite@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4):
     resolution: {integrity: sha512-IUd3vvxsiVefRDNDC3uJ+YYtrQtAPJQ02uvipmuI5CZtOuDc99hCrXVTeDDU6FobJ3K/vdnG3frDZP3uhTd1mQ==}
     peerDependencies:
       vite: ^5.0.0
       vitest: ^1.0.0
     dependencies:
-      '@nrwl/vite': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
+      '@nrwl/vite': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(vite@5.0.0)(vitest@1.0.4)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.2)
       '@swc/helpers': 0.5.2
       enquirer: 2.3.6
       tsconfig-paths: 4.2.0
-      vite: 5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
-      vitest: 1.0.4(@types/node@20.0.0)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
+      vite: 5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
+      vitest: 1.0.4(@types/node@20.11.30)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4520,12 +4493,12 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/web@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2):
+  /@nx/web@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2):
     resolution: {integrity: sha512-lcZjFEUjFly/+C4dFMLNEk9mnlolKGPrd4Z5tly0iEZCJ1tSuOYfxPraZZJFeYO88Eh10lW28aGdiHote/PLXQ==}
     dependencies:
-      '@nrwl/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nrwl/web': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       chalk: 4.1.2
       detect-port: 1.5.1
       http-server: 14.1.1
@@ -4543,13 +4516,13 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/webpack@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4):
+  /@nx/webpack@18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-ugac88EiCDtt/WVeuR596FJanN6J4Y8EPNxO/4+Odh6+yumgQdi0Bg6OLsvmZn6M+v+Qwaqyjo5RIFMk/3pDLQ==}
     dependencies:
       '@babel/core': 7.24.3
-      '@nrwl/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
+      '@nrwl/webpack': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)(webpack-cli@5.1.4)
       '@nx/devkit': 18.0.4(nx@18.0.4)
-      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.0.0)(nx@18.0.4)(typescript@5.3.2)
+      '@nx/js': 18.0.4(@swc-node/register@1.8.0)(@swc/core@1.3.85)(@types/node@20.11.30)(nx@18.0.4)(typescript@5.3.2)
       ajv: 8.12.0
       autoprefixer: 10.4.13(postcss@8.4.21)
       babel-loader: 9.1.3(@babel/core@7.24.3)(webpack@5.91.0)
@@ -4575,11 +4548,11 @@ packages:
       style-loader: 3.3.4(webpack@5.91.0)
       stylus: 0.59.0
       stylus-loader: 7.1.3(stylus@0.59.0)(webpack@5.91.0)
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.85)(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.101)(esbuild@0.19.11)(webpack@5.91.0)
       ts-loader: 9.5.1(typescript@5.3.2)(webpack@5.91.0)
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.3.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.91.0)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(webpack@5.91.0)
@@ -6419,7 +6392,7 @@ packages:
     resolution: {integrity: sha512-0HejFckBN2W+ucM6cUOlwsByTKt9/+0tWhqUffNIcHqCXkthY/mZ7AuYPK/2IIaGWhdl0h+tICDO0ssLMd6XMQ==}
     dev: true
 
-  /@rushstack/node-core-library@3.66.1(@types/node@20.0.0):
+  /@rushstack/node-core-library@3.66.1(@types/node@20.11.30):
     resolution: {integrity: sha512-ker69cVKAoar7MMtDFZC4CzcDxjwqIhFzqEnYI5NRN/8M3om6saWCVx/A7vL2t/jFCJsnzQplRDqA7c78pytng==}
     peerDependencies:
       '@types/node': '*'
@@ -6427,7 +6400,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -6437,7 +6410,7 @@ packages:
       z-schema: 5.0.5
     dev: true
 
-  /@rushstack/node-core-library@4.0.2(@types/node@20.0.0):
+  /@rushstack/node-core-library@4.0.2(@types/node@20.11.30):
     resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
@@ -6445,7 +6418,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -6461,7 +6434,7 @@ packages:
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/terminal@0.10.0(@types/node@20.0.0):
+  /@rushstack/terminal@0.10.0(@types/node@20.11.30):
     resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
     peerDependencies:
       '@types/node': '*'
@@ -6469,15 +6442,15 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.0.0)
-      '@types/node': 20.0.0
+      '@rushstack/node-core-library': 4.0.2(@types/node@20.11.30)
+      '@types/node': 20.11.30
       supports-color: 8.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.19.1(@types/node@20.0.0):
+  /@rushstack/ts-command-line@4.19.1(@types/node@20.11.30):
     resolution: {integrity: sha512-J7H768dgcpG60d7skZ5uSSwyCZs/S2HrWP1Ds8d1qYAyaaeJmpmmLr9BVw97RjFzmQPOYnoXcKA4GkqDCkduQg==}
     dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@20.0.0)
+      '@rushstack/terminal': 0.10.0(@types/node@20.11.30)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6712,7 +6685,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-arm64@1.3.85:
@@ -6729,7 +6701,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-x64@1.3.85:
@@ -6746,7 +6717,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.85:
@@ -6763,7 +6733,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.85:
@@ -6780,7 +6749,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.85:
@@ -6797,7 +6765,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.85:
@@ -6814,7 +6781,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.85:
@@ -6831,7 +6797,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.85:
@@ -6848,7 +6813,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.85:
@@ -6865,7 +6829,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.85:
@@ -6900,7 +6863,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.101
       '@swc/core-win32-ia32-msvc': 1.3.101
       '@swc/core-win32-x64-msvc': 1.3.101
-    dev: false
 
   /@swc/core@1.3.85(@swc/helpers@0.5.2):
     resolution: {integrity: sha512-qnoxp+2O0GtvRdYnXgR1v8J7iymGGYpx6f6yCK9KxipOZOjrlKILFANYlghQxZyPUfXwK++TFxfSlX4r9wK+kg==}
@@ -7240,7 +7202,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
     dev: true
@@ -7255,7 +7217,7 @@ packages:
   /@types/jsonwebtoken@9.0.6:
     resolution: {integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==}
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
 
   /@types/lodash.groupby@4.6.9:
     resolution: {integrity: sha512-z2xtCX2ko7GrqORnnYea4+ksT7jZNAvaOcLd6mP9M7J09RHvJs06W8BGdQQAX8ARef09VQLdeRilSOcfHlDQJQ==}
@@ -7291,9 +7253,6 @@ packages:
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: false
-
-  /@types/node@20.0.0:
-    resolution: {integrity: sha512-cD2uPTDnQQCVpmRefonO98/PPijuOnnEy5oytWJFPY1N9aJCz2wJ5kSGWO+zJoed2cY2JxQh6yBuUq4vIn61hw==}
 
   /@types/node@20.11.30:
     resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
@@ -7846,7 +7805,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@20.0.0)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
+      vitest: 1.0.4(@types/node@20.11.30)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7893,7 +7852,7 @@ packages:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.0.4(@types/node@20.0.0)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
+      vitest: 1.0.4(@types/node@20.11.30)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0)
     dev: true
 
   /@vitest/utils@1.0.4:
@@ -8002,7 +7961,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8012,7 +7971,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8026,7 +7985,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@xtuc/ieee754@1.2.0:
@@ -8516,7 +8475,7 @@ packages:
       '@babel/core': 7.24.3
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /babel-plugin-const-enum@1.2.0(@babel/core@7.24.3):
@@ -9270,7 +9229,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /core-js-compat@3.36.1:
@@ -9332,7 +9291,7 @@ packages:
       typescript: 5.3.2
     dev: true
 
-  /create-jest@29.7.0(@types/node@20.0.0)(ts-node@10.9.1):
+  /create-jest@29.7.0(@types/node@20.11.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -9341,7 +9300,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9404,7 +9363,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /css-minimizer-webpack-plugin@5.0.1(webpack@5.91.0):
@@ -9438,7 +9397,7 @@ packages:
       postcss: 8.4.38
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /css-select@5.1.0:
@@ -10287,7 +10246,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
-    dev: false
 
   /esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
@@ -11150,7 +11108,7 @@ packages:
       semver: 7.6.0
       tapable: 2.2.1
       typescript: 5.3.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /form-data@2.5.1:
@@ -12319,7 +12277,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.0.0)(ts-node@10.9.1):
+  /jest-cli@29.7.0(@types/node@20.11.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -12333,10 +12291,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      create-jest: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -12347,7 +12305,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@20.0.0)(ts-node@10.9.1):
+  /jest-config@29.7.0(@types/node@20.11.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -12362,7 +12320,7 @@ packages:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       babel-jest: 29.7.0(@babel/core@7.24.3)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -12382,7 +12340,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12429,7 +12387,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -12446,7 +12404,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -12525,7 +12483,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       jest-util: 29.7.0
     dev: true
 
@@ -12663,7 +12621,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12714,7 +12672,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.4.1(@types/node@20.0.0)(ts-node@10.9.1):
+  /jest@29.4.1(@types/node@20.11.30)(ts-node@10.9.1):
     resolution: {integrity: sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -12727,7 +12685,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.1)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.0.0)(ts-node@10.9.1)
+      jest-cli: 29.7.0(@types/node@20.11.30)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13030,7 +12988,7 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /less@4.1.3:
@@ -13070,8 +13028,10 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
+      webpack-sources:
+        optional: true
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-sources: 3.2.3
     dev: true
 
@@ -13522,7 +13482,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -14469,7 +14429,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.21
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2)
       yaml: 1.10.2
     dev: true
 
@@ -14487,7 +14447,7 @@ packages:
     dependencies:
       lilconfig: 3.1.1
       postcss: 8.4.38
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2)
       yaml: 2.4.1
     dev: false
 
@@ -14502,7 +14462,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.21
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /postcss-merge-longhand@6.0.5(postcss@8.4.38):
@@ -15573,7 +15533,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.72.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /sass@1.72.0:
@@ -15979,7 +15939,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /source-map-support@0.5.13:
@@ -16297,7 +16257,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /styled-components@6.1.8(react-dom@18.2.0)(react@18.2.0):
@@ -16362,7 +16322,7 @@ packages:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.59.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /stylus@0.59.0:
@@ -16590,31 +16550,6 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.29.2
       webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
-    dev: false
-
-  /terser-webpack-plugin@5.3.10(@swc/core@1.3.85)(webpack@5.91.0):
-    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.29.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
 
   /terser@5.29.2:
     resolution: {integrity: sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==}
@@ -16789,7 +16724,7 @@ packages:
       babel-jest: 29.4.1(@babel/core@7.24.3)
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1(@types/node@20.0.0)(ts-node@10.9.1)
+      jest: 29.4.1(@types/node@20.11.30)(ts-node@10.9.1)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -16812,7 +16747,7 @@ packages:
       semver: 7.6.0
       source-map: 0.7.4
       typescript: 5.3.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /ts-morph@18.0.0:
@@ -16822,7 +16757,7 @@ packages:
       code-block-writer: 12.0.0
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.85)(@types/node@20.0.0)(typescript@5.3.2):
+  /ts-node@10.9.1(@swc/core@1.3.85)(@types/node@20.11.30)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -16842,7 +16777,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -17131,7 +17066,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /url-parse@1.5.10:
@@ -17223,7 +17158,7 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /vite-node@1.0.4(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0):
+  /vite-node@1.0.4(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0):
     resolution: {integrity: sha512-9xQQtHdsz5Qn8hqbV7UKqkm8YkJhzT/zr41Dmt5N7AlD8hJXw/Z7y0QiD5I8lnTthV9Rvcvi0QW7PI0Fq83ZPg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -17232,7 +17167,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
+      vite: 5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -17244,30 +17179,30 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@2.3.0(@types/node@20.0.0)(vite@5.0.0):
+  /vite-plugin-dts@2.3.0(@types/node@20.11.30)(vite@5.0.0):
     resolution: {integrity: sha512-WbJgGtsStgQhdm3EosYmIdTGbag5YQpZ3HXWUAPCDyoXI5qN6EY0V7NXq0lAmnv9hVQsvh0htbYcg0Or5Db9JQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: '>=2.9.0'
     dependencies:
       '@babel/parser': 7.24.1
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.0.0)
+      '@microsoft/api-extractor': 7.43.0(@types/node@20.11.30)
       '@rollup/pluginutils': 5.1.0
-      '@rushstack/node-core-library': 3.66.1(@types/node@20.0.0)
+      '@rushstack/node-core-library': 3.66.1(@types/node@20.11.30)
       debug: 4.3.4
       fast-glob: 3.3.2
       fs-extra: 10.1.0
       kolorist: 1.8.0
       magic-string: 0.29.0
       ts-morph: 18.0.0
-      vite: 5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
+      vite: 5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
     dev: true
 
-  /vite@5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0):
+  /vite@5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0):
     resolution: {integrity: sha512-ESJVM59mdyGpsiNAeHQOR/0fqNoOyWPYesFto8FFZugfmhdHx8Fzd8sF3Q/xkVhZsyOxHfdM7ieiVAorI9RjFw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -17295,7 +17230,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       esbuild: 0.19.12
       less: 4.1.3
       postcss: 8.4.38
@@ -17305,7 +17240,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.0.4(@types/node@20.0.0)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0):
+  /vitest@1.0.4(@types/node@20.11.30)(@vitest/ui@1.0.4)(less@4.1.3)(stylus@0.59.0):
     resolution: {integrity: sha512-s1GQHp/UOeWEo4+aXDOeFBJwFzL6mjycbQwwKWX2QcYfh/7tIerS59hWQ20mxzupTJluA2SdwiBuWwQHH67ckg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -17330,7 +17265,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.0.0
+      '@types/node': 20.11.30
       '@vitest/expect': 1.0.4
       '@vitest/runner': 1.0.4
       '@vitest/snapshot': 1.0.4
@@ -17350,8 +17285,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.0(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
-      vite-node: 1.0.4(@types/node@20.0.0)(less@4.1.3)(stylus@0.59.0)
+      vite: 5.0.0(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
+      vite-node: 1.0.4(@types/node@20.11.30)(less@4.1.3)(stylus@0.59.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -17431,7 +17366,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   /webpack-dev-middleware@5.3.4(webpack@5.91.0):
@@ -17445,7 +17380,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -17489,7 +17424,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
       webpack-dev-middleware: 5.3.4(webpack@5.91.0)
       ws: 8.16.0
@@ -17528,7 +17463,7 @@ packages:
         optional: true
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /webpack@5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4):
@@ -17563,47 +17498,6 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.3.101)(esbuild@0.19.11)(webpack@5.91.0)
-      watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.91.0)
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: false
-
-  /webpack@5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4):
-    resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.23.0
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.0
-      es-module-lexer: 1.4.2
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.85)(webpack@5.91.0)
       watchpack: 2.4.1
       webpack-cli: 5.1.4(webpack@5.91.0)
       webpack-sources: 3.2.3
@@ -17927,3 +17821,7 @@ packages:
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add authorization guard

Usage:

Add `@UseGuards(AuthGuard("FirebaseJWT"))` or `@UseGuards(AuthGuard("RecnetJWT"))` before the endpoint which needs authorization and depends on which kind of JWT is expected.
And use `utils` function to extract decoded payload (only for `RecnetJWT`).

![Screenshot 2024-03-23 at 10 14 38 PM](https://github.com/lil-lab/recnet/assets/71842426/22907de0-dfa7-419f-899c-721daee7d840)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
1. Remember to add `Bearer token` when using postman 

2. Ref: 
  - https://stackoverflow.com/questions/62046413/is-it-possible-to-pass-a-parameter-to-a-nestjs-guard
  - https://docs.nestjs.com/guards#setting-roles-per-handler
  - https://docs.nestjs.com/security/authentication#implementing-the-authentication-guard
  - https://stackoverflow.com/questions/58714466/in-nestjs-is-there-any-way-to-pass-data-from-guards-to-the-controller

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
