### PR TITLE
[recnet-api] Add nullcheck to correct type infering from DTO

### DIFF
--- a/apps/recnet-api/src/config/env.schema.ts
+++ b/apps/recnet-api/src/config/env.schema.ts
@@ -18,7 +18,7 @@ export const EnvSchema = z.object({
   DB_MIGRATE: z.coerce.boolean().optional().default(false),
 });
 
-export const parseEnv = (env: Record<string, string>) => {
+export const parseEnv = (env: Record<string, string | undefined>) => {
   const parsedEnv = EnvSchema.parse(env);
   return parsedEnv;
 };

--- a/apps/recnet-api/src/modules/user/entities/user.preview.entity.ts
+++ b/apps/recnet-api/src/modules/user/entities/user.preview.entity.ts
@@ -14,10 +14,10 @@ export class UserPreview {
   photoUrl: string;
 
   @ApiProperty()
-  affiliation: string;
+  affiliation: string | null;
 
   @ApiProperty()
-  bio: string;
+  bio: string | null;
 
   @ApiProperty()
   numFollowers: number;

--- a/apps/recnet-api/src/utils/middlewares/logger.middleware.ts
+++ b/apps/recnet-api/src/utils/middlewares/logger.middleware.ts
@@ -8,7 +8,7 @@ export class LoggerMiddleware implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction) {
     const { method, originalUrl, body, headers } = req;
-    const requestId = uuidv4().substr(0, 8);
+    const requestId = uuidv4().slice(0, 8);
 
     const requestDetails = {
       method,

--- a/apps/recnet-api/src/utils/pipes/zod.validation.pipe.ts
+++ b/apps/recnet-api/src/utils/pipes/zod.validation.pipe.ts
@@ -1,5 +1,5 @@
 import { PipeTransform, HttpStatus } from "@nestjs/common";
-import { ZodSchema } from "zod";
+import { ZodError, ZodSchema } from "zod";
 
 import { RecnetError } from "@recnet-api/utils/error/recnet.error";
 import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
@@ -16,7 +16,7 @@ export class ZodValidationPipe implements PipeTransform {
         ErrorCode.ZOD_VALIDATION_ERROR,
         HttpStatus.BAD_REQUEST,
         undefined,
-        JSON.parse(error.message)
+        JSON.parse((error as ZodError).message)
       );
     }
   }

--- a/apps/recnet-api/tsconfig.app.json
+++ b/apps/recnet-api/tsconfig.app.json
@@ -5,7 +5,9 @@
     "module": "commonjs",
     "types": ["node"],
     "emitDecoratorMetadata": true,
-    "target": "es2021"
+    "target": "es2021",
+    "strictNullChecks": true,
+    "strict": true
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]

--- a/apps/recnet-api/tsconfig.app.json
+++ b/apps/recnet-api/tsconfig.app.json
@@ -7,7 +7,8 @@
     "emitDecoratorMetadata": true,
     "target": "es2021",
     "strictNullChecks": true,
-    "strict": true
+    "strict": true,
+    "strictPropertyInitialization": false
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/node": "^20",
     "@types/react": "^18.2.67",
     "@types/react-dom": "^18.2.22",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.13.2",
     "@vitest/coverage-v8": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@hookform/resolvers':
     specifier: ^3.3.4
@@ -238,6 +234,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.2.22
     version: 18.2.22
+  '@types/uuid':
+    specifier: ^9.0.8
+    version: 9.0.8
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.19.1
     version: 6.19.1(@typescript-eslint/parser@6.13.2)(eslint@8.48.0)(typescript@5.3.2)
@@ -1960,7 +1959,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/aix-ppc64@0.19.12:
@@ -1978,7 +1976,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm64@0.19.12:
@@ -1996,7 +1993,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.19.12:
@@ -2014,7 +2010,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.19.12:
@@ -2032,7 +2027,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.19.12:
@@ -2050,7 +2044,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.19.12:
@@ -2068,7 +2061,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.12:
@@ -2086,7 +2078,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.19.12:
@@ -2104,7 +2095,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.19.12:
@@ -2122,7 +2112,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.19.12:
@@ -2140,7 +2129,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.19.12:
@@ -2158,7 +2146,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.19.12:
@@ -2176,7 +2163,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.19.12:
@@ -2194,7 +2180,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.19.12:
@@ -2212,7 +2197,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.19.12:
@@ -2230,7 +2214,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.19.12:
@@ -2248,7 +2231,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.19.12:
@@ -2266,7 +2248,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.19.12:
@@ -2284,7 +2265,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.19.12:
@@ -2302,7 +2282,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.19.12:
@@ -2320,7 +2299,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.19.12:
@@ -2338,7 +2316,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.19.12:
@@ -2356,7 +2333,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.19.12:
@@ -4575,11 +4551,11 @@ packages:
       style-loader: 3.3.4(webpack@5.91.0)
       stylus: 0.59.0
       stylus-loader: 7.1.3(stylus@0.59.0)(webpack@5.91.0)
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.85)(webpack@5.91.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.101)(esbuild@0.19.11)(webpack@5.91.0)
       ts-loader: 9.5.1(typescript@5.3.2)(webpack@5.91.0)
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.3.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.91.0)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(webpack@5.91.0)
@@ -6712,7 +6688,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-arm64@1.3.85:
@@ -6729,7 +6704,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-x64@1.3.85:
@@ -6746,7 +6720,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.3.85:
@@ -6763,7 +6736,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-gnu@1.3.85:
@@ -6780,7 +6752,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl@1.3.85:
@@ -6797,7 +6768,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu@1.3.85:
@@ -6814,7 +6784,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-musl@1.3.85:
@@ -6831,7 +6800,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc@1.3.85:
@@ -6848,7 +6816,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.3.85:
@@ -6865,7 +6832,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-x64-msvc@1.3.85:
@@ -6900,7 +6866,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.3.101
       '@swc/core-win32-ia32-msvc': 1.3.101
       '@swc/core-win32-x64-msvc': 1.3.101
-    dev: false
 
   /@swc/core@1.3.85(@swc/helpers@0.5.2):
     resolution: {integrity: sha512-qnoxp+2O0GtvRdYnXgR1v8J7iymGGYpx6f6yCK9KxipOZOjrlKILFANYlghQxZyPUfXwK++TFxfSlX4r9wK+kg==}
@@ -7393,6 +7358,10 @@ packages:
 
   /@types/tough-cookie@4.0.5:
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  /@types/uuid@9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
+    dev: true
 
   /@types/webpack@5.28.5(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
@@ -8002,7 +7971,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8012,7 +7981,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -8026,7 +7995,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
 
   /@xtuc/ieee754@1.2.0:
@@ -8516,7 +8485,7 @@ packages:
       '@babel/core': 7.24.3
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /babel-plugin-const-enum@1.2.0(@babel/core@7.24.3):
@@ -9270,7 +9239,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /core-js-compat@3.36.1:
@@ -9404,7 +9373,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /css-minimizer-webpack-plugin@5.0.1(webpack@5.91.0):
@@ -9438,7 +9407,7 @@ packages:
       postcss: 8.4.38
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /css-select@5.1.0:
@@ -10287,7 +10256,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
-    dev: false
 
   /esbuild@0.19.12:
     resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
@@ -11150,7 +11118,7 @@ packages:
       semver: 7.6.0
       tapable: 2.2.1
       typescript: 5.3.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /form-data@2.5.1:
@@ -13030,7 +12998,7 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /less@4.1.3:
@@ -13070,8 +13038,10 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
+      webpack-sources:
+        optional: true
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-sources: 3.2.3
     dev: true
 
@@ -13522,7 +13492,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -14502,7 +14472,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.21
       semver: 7.6.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /postcss-merge-longhand@6.0.5(postcss@8.4.38):
@@ -15573,7 +15543,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.72.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /sass@1.72.0:
@@ -15979,7 +15949,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /source-map-support@0.5.13:
@@ -16297,7 +16267,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /styled-components@6.1.8(react-dom@18.2.0)(react@18.2.0):
@@ -16362,7 +16332,7 @@ packages:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.59.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /stylus@0.59.0:
@@ -16590,31 +16560,6 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.29.2
       webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
-    dev: false
-
-  /terser-webpack-plugin@5.3.10(@swc/core@1.3.85)(webpack@5.91.0):
-    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.29.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
 
   /terser@5.29.2:
     resolution: {integrity: sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==}
@@ -16812,7 +16757,7 @@ packages:
       semver: 7.6.0
       source-map: 0.7.4
       typescript: 5.3.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /ts-morph@18.0.0:
@@ -17131,7 +17076,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /url-parse@1.5.10:
@@ -17431,7 +17376,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   /webpack-dev-middleware@5.3.4(webpack@5.91.0):
@@ -17445,7 +17390,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.91.0):
@@ -17489,7 +17434,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.91.0)
       webpack-dev-middleware: 5.3.4(webpack@5.91.0)
       ws: 8.16.0
@@ -17528,7 +17473,7 @@ packages:
         optional: true
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4)
+      webpack: 5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4)
     dev: true
 
   /webpack@5.91.0(@swc/core@1.3.101)(esbuild@0.19.11)(webpack-cli@5.1.4):
@@ -17563,47 +17508,6 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.3.101)(esbuild@0.19.11)(webpack@5.91.0)
-      watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.91.0)
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: false
-
-  /webpack@5.91.0(@swc/core@1.3.85)(webpack-cli@5.1.4):
-    resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.11.3
-      acorn-import-assertions: 1.9.0(acorn@8.11.3)
-      browserslist: 4.23.0
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.0
-      es-module-lexer: 1.4.2
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.3.85)(webpack@5.91.0)
       watchpack: 2.4.1
       webpack-cli: 5.1.4(webpack@5.91.0)
       webpack-sources: 3.2.3
@@ -17927,3 +17831,7 @@ packages:
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add `strictNullChecks` to help typescript correctly inferring type from Dto.

If I did not add this, even we mark some field as optional or nullable in DTO files, typescript won't know and will seem it as non-nullable or non-undefined.

After setting this, I found some type issues (ex: `UserPreview` did not define correctly in `user.preview.entity`) and solved them in this PR.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## TODO

