### PR TITLE
[recnet-api] Finish Invite Code APIs and Stats API

### DIFF
--- a/apps/recnet-api/src/app.module.ts
+++ b/apps/recnet-api/src/app.module.ts
@@ -5,6 +5,7 @@ import * as CommonConfigs from "./config/common.config";
 import { parseEnv } from "./config/env.schema";
 import { ArticleModule } from "./modules/article/article.module";
 import { HealthModule } from "./modules/health/health.module";
+import { InviteCodeModule } from "./modules/invite-code/invite-code.module";
 import { RecModule } from "./modules/rec/rec.module";
 import { UserModule } from "./modules/user/user.module";
 import { LoggerMiddleware } from "./utils/middlewares/logger.middleware";
@@ -20,6 +21,7 @@ import { LoggerMiddleware } from "./utils/middlewares/logger.middleware";
     UserModule,
     RecModule,
     ArticleModule,
+    InviteCodeModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/recnet-api/src/app.module.ts
+++ b/apps/recnet-api/src/app.module.ts
@@ -7,6 +7,7 @@ import { ArticleModule } from "./modules/article/article.module";
 import { HealthModule } from "./modules/health/health.module";
 import { InviteCodeModule } from "./modules/invite-code/invite-code.module";
 import { RecModule } from "./modules/rec/rec.module";
+import { StatModule } from "./modules/stat/stat.module";
 import { UserModule } from "./modules/user/user.module";
 import { LoggerMiddleware } from "./utils/middlewares/logger.middleware";
 
@@ -22,6 +23,7 @@ import { LoggerMiddleware } from "./utils/middlewares/logger.middleware";
     RecModule,
     ArticleModule,
     InviteCodeModule,
+    StatModule,
   ],
   controllers: [],
   providers: [],

--- a/apps/recnet-api/src/database/repository/db.repository.module.ts
+++ b/apps/recnet-api/src/database/repository/db.repository.module.ts
@@ -3,12 +3,23 @@ import { Module } from "@nestjs/common";
 import { PrismaModule } from "@recnet-api/database/prisma/prisma.module";
 
 import ArticleRepository from "./article.repository";
+import InviteCodeRepository from "./invite-code.repository";
 import RecRepository from "./rec.repository";
 import UserRepository from "./user.repository";
 
 @Module({
   imports: [PrismaModule],
-  providers: [UserRepository, RecRepository, ArticleRepository],
-  exports: [UserRepository, RecRepository, ArticleRepository],
+  providers: [
+    UserRepository,
+    RecRepository,
+    ArticleRepository,
+    InviteCodeRepository,
+  ],
+  exports: [
+    UserRepository,
+    RecRepository,
+    ArticleRepository,
+    InviteCodeRepository,
+  ],
 })
 export class DbRepositoryModule {}

--- a/apps/recnet-api/src/database/repository/invite-code.repository.ts
+++ b/apps/recnet-api/src/database/repository/invite-code.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from "@nestjs/common";
+
+import PrismaConnectionProvider from "@recnet-api/database/prisma/prisma.connection.provider";
+
+@Injectable()
+export default class InviteCodeRepository {
+  constructor(private readonly prisma: PrismaConnectionProvider) {}
+
+  public async createInviteCode(
+    codes: string[],
+    ownerId: string
+  ): Promise<void> {
+    await this.prisma.inviteCode.createMany({
+      data: codes.map((code) => ({
+        code,
+        ownerId,
+        issuedAt: new Date(),
+      })),
+    });
+  }
+}

--- a/apps/recnet-api/src/database/repository/invite-code.repository.ts
+++ b/apps/recnet-api/src/database/repository/invite-code.repository.ts
@@ -1,6 +1,14 @@
 import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 
 import PrismaConnectionProvider from "@recnet-api/database/prisma/prisma.connection.provider";
+import { getOffset } from "@recnet-api/utils";
+
+import {
+  InviteCode,
+  inviteCode,
+  InviteCodeFilterBy,
+} from "./invite-code.repository.type";
 
 @Injectable()
 export default class InviteCodeRepository {
@@ -17,5 +25,37 @@ export default class InviteCodeRepository {
         issuedAt: new Date(),
       })),
     });
+  }
+
+  public async findInviteCodes(
+    page: number,
+    pageSize: number,
+    filter: InviteCodeFilterBy
+  ): Promise<InviteCode[]> {
+    return this.prisma.inviteCode.findMany({
+      select: inviteCode.select,
+      where: this.transformInviteCodeFilterByToPrismaWhere(filter),
+      take: pageSize,
+      skip: getOffset(page, pageSize),
+      orderBy: { issuedAt: Prisma.SortOrder.desc },
+    });
+  }
+
+  public async countInviteCodes(filter: InviteCodeFilterBy): Promise<number> {
+    return this.prisma.inviteCode.count({
+      where: this.transformInviteCodeFilterByToPrismaWhere(filter),
+    });
+  }
+
+  private transformInviteCodeFilterByToPrismaWhere(
+    filter: InviteCodeFilterBy
+  ): Prisma.InviteCodeWhereInput {
+    const where: Prisma.InviteCodeWhereInput = {};
+    if (filter.used === true) {
+      where.usedAt = { not: null };
+    } else if (filter.used === false) {
+      where.usedAt = null;
+    }
+    return where;
   }
 }

--- a/apps/recnet-api/src/database/repository/invite-code.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/invite-code.repository.type.ts
@@ -17,3 +17,7 @@ export const inviteCode = Prisma.validator<Prisma.InviteCodeDefaultArgs>()({
   },
 });
 export type InviteCode = Prisma.InviteCodeGetPayload<typeof inviteCode>;
+
+export type InviteCodeFilterBy = {
+  used?: boolean;
+};

--- a/apps/recnet-api/src/database/repository/invite-code.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/invite-code.repository.type.ts
@@ -1,0 +1,19 @@
+import { Prisma } from "@prisma/client";
+
+import { userPreview } from "./user.repository.type";
+
+export const inviteCode = Prisma.validator<Prisma.InviteCodeDefaultArgs>()({
+  select: {
+    id: true,
+    code: true,
+    owner: {
+      select: userPreview.select,
+    },
+    issuedAt: true,
+    usedBy: {
+      select: userPreview.select,
+    },
+    usedAt: true,
+  },
+});
+export type InviteCode = Prisma.InviteCodeGetPayload<typeof inviteCode>;

--- a/apps/recnet-api/src/database/repository/rec.repository.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.ts
@@ -15,7 +15,7 @@ export default class RecRepository {
   public async findRecs(
     page: number,
     pageSize: number,
-    filter: RecFilterBy
+    filter: RecFilterBy = {}
   ): Promise<Rec[]> {
     return this.prisma.recommendation.findMany({
       select: rec.select,
@@ -26,7 +26,7 @@ export default class RecRepository {
     });
   }
 
-  public async countRecs(filter: RecFilterBy): Promise<number> {
+  public async countRecs(filter: RecFilterBy = {}): Promise<number> {
     return this.prisma.recommendation.count({
       where: this.transformRecFilterByToPrismaWhere(filter),
     });
@@ -103,6 +103,19 @@ export default class RecRepository {
         id: recId,
       },
     });
+  }
+
+  public async getRecCountPerCutoff() {
+    const recCounts = await this.prisma.recommendation.groupBy({
+      by: ["cutoff"],
+      _count: {
+        _all: true,
+      },
+    });
+    return recCounts.map((entry) => ({
+      cutoff: entry.cutoff,
+      count: entry._count._all,
+    }));
   }
 
   private transformRecFilterByToPrismaWhere(

--- a/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateInviteCodeDto {
+  @ApiProperty()
+  ownerId: string;
+
+  @ApiProperty()
+  numCodes: number;
+}

--- a/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
@@ -4,6 +4,11 @@ export class CreateInviteCodeDto {
   @ApiProperty()
   ownerId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    maximum: 20,
+    minimum: 1,
+    description: "Number of invite codes to generate",
+    example: 5,
+  })
   numCodes: number;
 }

--- a/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/create.invite-code.dto.ts
@@ -1,7 +1,10 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class CreateInviteCodeDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: "Owner User ID of the invite codes",
+    example: "2bc2e909-4400-4e7e-8873-c20bfb65a0f9",
+  })
   ownerId: string;
 
   @ApiProperty({

--- a/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class QueryInviteCodeDto {
   @ApiProperty()
@@ -7,8 +7,9 @@ export class QueryInviteCodeDto {
   @ApiProperty()
   pageSize: number;
 
-  @ApiProperty({
-    description: "Whether should return only used codes or not",
+  @ApiPropertyOptional({
+    description:
+      "If used is true, it will only return invite codes that have been used. If it's false, it will only return invite codes that haven't been used. Otherwise, it will return all invite codes.",
     required: false,
     default: undefined,
   })

--- a/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
@@ -1,10 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
 export class QueryInviteCodeDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: "Page number",
+    example: 1,
+  })
   page: number;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: "Number of items per page",
+    example: 10,
+  })
   pageSize: number;
 
   @ApiPropertyOptional({

--- a/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
+++ b/apps/recnet-api/src/modules/invite-code/dto/query.invite-code.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class QueryInviteCodeDto {
+  @ApiProperty()
+  page: number;
+
+  @ApiProperty()
+  pageSize: number;
+
+  @ApiProperty({
+    description: "Whether should return only used codes or not",
+    required: false,
+    default: undefined,
+  })
+  used?: boolean;
+}

--- a/apps/recnet-api/src/modules/invite-code/entities/invite-code.entity.ts
+++ b/apps/recnet-api/src/modules/invite-code/entities/invite-code.entity.ts
@@ -4,7 +4,7 @@ import { UserPreview } from "@recnet-api/modules/user/entities/user.preview.enti
 
 export class InviteCode {
   @ApiProperty()
-  id: string;
+  id: number;
 
   @ApiProperty()
   code: string;

--- a/apps/recnet-api/src/modules/invite-code/entities/invite-code.entity.ts
+++ b/apps/recnet-api/src/modules/invite-code/entities/invite-code.entity.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+import { UserPreview } from "@recnet-api/modules/user/entities/user.preview.entity";
+
+export class InviteCode {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  code: string;
+
+  @ApiProperty()
+  owner: UserPreview;
+
+  @ApiProperty()
+  issuedAt: Date;
+
+  @ApiProperty()
+  usedBy: UserPreview | null;
+
+  @ApiProperty()
+  usedAt: Date | null;
+}

--- a/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Body, UseFilters, UsePipes, Post } from "@nestjs/common";
+import {
+  Controller,
+  Body,
+  UseFilters,
+  UsePipes,
+  Post,
+  Get,
+  Query,
+} from "@nestjs/common";
 import {
   ApiOkResponse,
   ApiOperation,
@@ -10,10 +18,17 @@ import { Auth } from "@recnet-api/utils/auth/auth.decorator";
 import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
 import { ZodValidationPipe } from "@recnet-api/utils/pipes/zod.validation.pipe";
 
-import { postInviteCodesRequestSchema } from "@recnet/recnet-api-model";
+import {
+  postInviteCodesRequestSchema,
+  getInviteCodesParamsSchema,
+} from "@recnet/recnet-api-model";
 
 import { CreateInviteCodeDto } from "./dto/create.invite-code.dto";
-import { CreateInviteCodeResponse } from "./invite-code.response";
+import { QueryInviteCodeDto } from "./dto/query.invite-code.dto";
+import {
+  CreateInviteCodeResponse,
+  GetInviteCodeResponse,
+} from "./invite-code.response";
 import { InviteCodeService } from "./invite-code.service";
 
 @ApiTags("invite-codes")
@@ -23,8 +38,8 @@ export class InviteCodeController {
   constructor(private readonly inviteCodeService: InviteCodeService) {}
 
   @ApiOperation({
-    summary: "Generate Invite Code",
-    description: "Generate n invite code and assign to target user.",
+    summary: "Generate Invite Codes",
+    description: "Generate n invite codes and assign to target user.",
   })
   @ApiOkResponse({ type: CreateInviteCodeResponse })
   @ApiBearerAuth()
@@ -36,5 +51,21 @@ export class InviteCodeController {
   ): Promise<CreateInviteCodeResponse> {
     const { numCodes, ownerId } = dto;
     return this.inviteCodeService.createInviteCode(numCodes, ownerId);
+  }
+
+  @ApiOperation({
+    summary: "Get Invite Codes",
+    description: "Get all invite codes with pagination.",
+  })
+  @ApiOkResponse({ type: GetInviteCodeResponse })
+  @ApiBearerAuth()
+  @Get()
+  @Auth()
+  @UsePipes(new ZodValidationPipe(getInviteCodesParamsSchema))
+  public async getInviteCodes(
+    @Query() dto: QueryInviteCodeDto
+  ): Promise<GetInviteCodeResponse> {
+    const { page, pageSize, ...filter } = dto;
+    return this.inviteCodeService.getInviteCodes(page, pageSize, filter);
   }
 }

--- a/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Body, UseFilters, UsePipes, Post } from "@nestjs/common";
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiBearerAuth,
+} from "@nestjs/swagger";
+
+import { Auth } from "@recnet-api/utils/auth/auth.decorator";
+import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
+import { ZodValidationPipe } from "@recnet-api/utils/pipes/zod.validation.pipe";
+
+import { postInviteCodesRequestSchema } from "@recnet/recnet-api-model";
+
+import { CreateInviteCodeDto } from "./dto/create.invite-code.dto";
+import { CreateInviteCodeResponse } from "./invite-code.response";
+import { InviteCodeService } from "./invite-code.service";
+
+@ApiTags("invite-codes")
+@Controller("invite-codes")
+@UseFilters(RecnetExceptionFilter)
+export class InviteCodeController {
+  constructor(private readonly inviteCodeService: InviteCodeService) {}
+
+  @ApiOperation({
+    summary: "Generate Invite Code",
+    description: "Generate n invite code and assign to target user.",
+  })
+  @ApiOkResponse({ type: CreateInviteCodeResponse })
+  @ApiBearerAuth()
+  @Post()
+  @Auth()
+  @UsePipes(new ZodValidationPipe(postInviteCodesRequestSchema))
+  public async createInviteCode(
+    @Body() dto: CreateInviteCodeDto
+  ): Promise<CreateInviteCodeResponse> {
+    const { numCodes, ownerId } = dto;
+    return this.inviteCodeService.createInviteCode(numCodes, ownerId);
+  }
+}

--- a/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
@@ -44,7 +44,7 @@ export class InviteCodeController {
   @ApiOkResponse({ type: CreateInviteCodeResponse })
   @ApiBearerAuth()
   @Post()
-  @Auth()
+  @Auth(["ADMIN"])
   @UsePipes(new ZodValidationPipe(postInviteCodesRequestSchema))
   public async createInviteCode(
     @Body() dto: CreateInviteCodeDto
@@ -60,7 +60,7 @@ export class InviteCodeController {
   @ApiOkResponse({ type: GetInviteCodeResponse })
   @ApiBearerAuth()
   @Get()
-  @Auth()
+  @Auth(["ADMIN"])
   @UsePipes(new ZodValidationPipe(getInviteCodesParamsSchema))
   public async getInviteCodes(
     @Query() dto: QueryInviteCodeDto

--- a/apps/recnet-api/src/modules/invite-code/invite-code.module.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+
+import { DbRepositoryModule } from "@recnet-api/database/repository/db.repository.module";
+
+import { InviteCodeController } from "./invite-code.controller";
+import { InviteCodeService } from "./invite-code.service";
+
+@Module({
+  controllers: [InviteCodeController],
+  providers: [InviteCodeService],
+  imports: [DbRepositoryModule],
+})
+export class InviteCodeModule {}

--- a/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
@@ -1,6 +1,16 @@
 import { ApiProperty } from "@nestjs/swagger";
 
+import { InviteCode } from "./entities/invite-code.entity";
+
 export class CreateInviteCodeResponse {
   @ApiProperty()
-  inviteCodes: string[];
+  codes: string[];
+}
+
+export class GetInviteCodeResponse {
+  @ApiProperty()
+  hasNext: boolean;
+
+  @ApiProperty()
+  inviteCodes: InviteCode[];
 }

--- a/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
@@ -11,6 +11,6 @@ export class GetInviteCodeResponse {
   @ApiProperty()
   hasNext: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ type: [InviteCode] })
   inviteCodes: InviteCode[];
 }

--- a/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.response.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateInviteCodeResponse {
+  @ApiProperty()
+  inviteCodes: string[];
+}

--- a/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from "@nestjs/common";
+import Chance from "chance";
+
+import InviteCodeRepository from "@recnet-api/database/repository/invite-code.repository";
+
+import { CreateInviteCodeResponse } from "./invite-code.response";
+
+@Injectable()
+export class InviteCodeService {
+  constructor(
+    @Inject(InviteCodeRepository)
+    private readonly inviteCodeRepository: InviteCodeRepository
+  ) {}
+
+  public async createInviteCode(
+    numCodes: number,
+    ownerId: string
+  ): Promise<CreateInviteCodeResponse> {
+    const codes = Array.from({ length: numCodes }, () => this.genRandomCode());
+    await this.inviteCodeRepository.createInviteCode(codes, ownerId);
+    return {
+      inviteCodes: codes,
+    };
+  }
+
+  private genRandomCode(): string {
+    const chance = new Chance();
+    const code = chance.string({
+      length: 16,
+      pool: "abcdefghijklmnopqrstuvwxyz0123456789",
+    });
+    // split the code into 4 parts
+    return (code.match(/.{1,4}/g) as string[]).join("-");
+  }
+}

--- a/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
@@ -19,7 +19,7 @@ export class InviteCodeService {
     const codes = Array.from({ length: numCodes }, () => this.genRandomCode());
     await this.inviteCodeRepository.createInviteCode(codes, ownerId);
     return {
-      inviteCodes: codes,
+      codes: codes,
     };
   }
 

--- a/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
@@ -2,8 +2,17 @@ import { Inject, Injectable } from "@nestjs/common";
 import Chance from "chance";
 
 import InviteCodeRepository from "@recnet-api/database/repository/invite-code.repository";
+import {
+  InviteCode as DbInviteCode,
+  InviteCodeFilterBy,
+} from "@recnet-api/database/repository/invite-code.repository.type";
+import { getOffset } from "@recnet-api/utils";
 
-import { CreateInviteCodeResponse } from "./invite-code.response";
+import { InviteCode } from "./entities/invite-code.entity";
+import {
+  CreateInviteCodeResponse,
+  GetInviteCodeResponse,
+} from "./invite-code.response";
 
 @Injectable()
 export class InviteCodeService {
@@ -20,6 +29,63 @@ export class InviteCodeService {
     await this.inviteCodeRepository.createInviteCode(codes, ownerId);
     return {
       codes: codes,
+    };
+  }
+
+  public async getInviteCodes(
+    page: number,
+    pageSize: number,
+    filter: InviteCodeFilterBy
+  ): Promise<GetInviteCodeResponse> {
+    const inviteCodeCount =
+      await this.inviteCodeRepository.countInviteCodes(filter);
+    const dbInviteCodes = await this.inviteCodeRepository.findInviteCodes(
+      page,
+      pageSize,
+      filter
+    );
+    const inviteCodes = this.getInviteCodesFromDbInviteCodes(dbInviteCodes);
+
+    return {
+      hasNext: inviteCodes.length + getOffset(page, pageSize) < inviteCodeCount,
+      inviteCodes: inviteCodes,
+    };
+  }
+
+  private getInviteCodesFromDbInviteCodes(
+    dbInviteCodes: DbInviteCode[]
+  ): InviteCode[] {
+    return dbInviteCodes.map(this.getInviteCodeFromDbInviteCode);
+  }
+
+  private getInviteCodeFromDbInviteCode(
+    dbInviteCode: DbInviteCode
+  ): InviteCode {
+    return {
+      id: dbInviteCode.id,
+      code: dbInviteCode.code,
+      owner: {
+        id: dbInviteCode.owner.id,
+        handle: dbInviteCode.owner.handle,
+        displayName: dbInviteCode.owner.displayName,
+        photoUrl: dbInviteCode.owner.photoUrl,
+        affiliation: dbInviteCode.owner.affiliation,
+        bio: dbInviteCode.owner.bio,
+        numFollowers: dbInviteCode.owner.followedBy.length,
+      },
+      issuedAt: dbInviteCode.issuedAt,
+      usedAt: dbInviteCode.usedAt,
+      usedBy: dbInviteCode.usedBy
+        ? {
+            id: dbInviteCode.usedBy.id,
+            handle: dbInviteCode.usedBy.handle,
+            displayName: dbInviteCode.usedBy.displayName,
+            photoUrl: dbInviteCode.usedBy.photoUrl,
+            affiliation: dbInviteCode.usedBy.affiliation,
+            bio: dbInviteCode.usedBy.bio,
+            numFollowers: dbInviteCode.usedBy.followedBy.length,
+          }
+        : null,
     };
   }
 

--- a/apps/recnet-api/src/modules/stat/stat.controller.ts
+++ b/apps/recnet-api/src/modules/stat/stat.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, UseFilters, Get } from "@nestjs/common";
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiBearerAuth,
+} from "@nestjs/swagger";
+
+import { Auth } from "@recnet-api/utils/auth/auth.decorator";
+import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
+
+import { QueryStatResponse } from "./stat.response";
+import { StatService } from "./stat.service";
+
+@ApiTags("stats")
+@Controller("stats")
+@UseFilters(RecnetExceptionFilter)
+export class StatController {
+  constructor(private readonly statService: StatService) {}
+
+  @ApiOperation({
+    summary: "Get Stats",
+    description: "Get all stats related to user & rec data",
+  })
+  @ApiOkResponse({ type: QueryStatResponse })
+  @ApiBearerAuth()
+  @Get()
+  @Auth(["ADMIN"])
+  public async getStats(): Promise<QueryStatResponse> {
+    return this.statService.getStats();
+  }
+}

--- a/apps/recnet-api/src/modules/stat/stat.module.ts
+++ b/apps/recnet-api/src/modules/stat/stat.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+
+import { DbRepositoryModule } from "@recnet-api/database/repository/db.repository.module";
+
+import { StatController } from "./stat.controller";
+import { StatService } from "./stat.service";
+
+@Module({
+  controllers: [StatController],
+  providers: [StatService],
+  imports: [DbRepositoryModule],
+})
+export class StatModule {}

--- a/apps/recnet-api/src/modules/stat/stat.response.ts
+++ b/apps/recnet-api/src/modules/stat/stat.response.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class QueryStatResponse {
+  @ApiProperty()
+  numUsers: number;
+
+  @ApiProperty()
+  numRecs: number;
+
+  @ApiProperty()
+  numUpcomingRecs: number;
+
+  @ApiProperty()
+  numRecsOverTime: Record<string, number>;
+}

--- a/apps/recnet-api/src/modules/stat/stat.service.ts
+++ b/apps/recnet-api/src/modules/stat/stat.service.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import RecRepository from "@recnet-api/database/repository/rec.repository";
+import UserRepository from "@recnet-api/database/repository/user.repository";
+
+import { getNextCutOff } from "@recnet/recnet-date-fns";
+
+import { QueryStatResponse } from "./stat.response";
+
+@Injectable()
+export class StatService {
+  constructor(
+    @Inject(UserRepository)
+    private readonly userRepository: UserRepository,
+    @Inject(RecRepository)
+    private readonly recRepository: RecRepository
+  ) {}
+
+  public async getStats(): Promise<QueryStatResponse> {
+    const numUsers = await this.userRepository.countUsers();
+    const numRecs = await this.recRepository.countRecs();
+    const numUpcomingRecs = await this.recRepository.countRecs({
+      cutoff: getNextCutOff(),
+    });
+    const recCountPerCycle = await this.recRepository.getRecCountPerCutoff();
+
+    return {
+      numUsers,
+      numRecs,
+      numUpcomingRecs,
+      numRecsOverTime: recCountPerCycle.reduce((acc, data) => {
+        const ts = data.cutoff.getTime();
+        const count = data.count;
+        return {
+          ...acc,
+          [ts]: count,
+        };
+      }, {}),
+    };
+  }
+}

--- a/apps/recnet-api/src/utils/auth/auth.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.decorator.ts
@@ -1,16 +1,18 @@
-import { UseGuards } from "@nestjs/common";
+import { UseGuards, applyDecorators } from "@nestjs/common";
 
-import {
-  firebaseJwtPayloadSchema,
-  recnetJwtPayloadSchema,
-  verifyFirebaseJwt,
-  verifyRecnetJwt,
-} from "@recnet/recnet-jwt";
+import { verifyFirebaseJwt, verifyRecnetJwt } from "@recnet/recnet-jwt";
+
+import { UserRole } from "@recnet/recnet-api-model";
 
 import { AuthGuard } from "./auth.guard";
+import { RoleGuard } from "./role.guard";
 
-export const Auth = () =>
-  UseGuards(new AuthGuard(verifyRecnetJwt, recnetJwtPayloadSchema));
+// RoleGuard must be placed after AuthGuard since it need to access the user info in the request
+export const Auth = (allowedRoles?: UserRole[]) => {
+  return applyDecorators(
+    UseGuards(new AuthGuard(verifyRecnetJwt)),
+    UseGuards(RoleGuard(allowedRoles))
+  );
+};
 
-export const AuthFirebase = () =>
-  UseGuards(new AuthGuard(verifyFirebaseJwt, firebaseJwtPayloadSchema));
+export const AuthFirebase = () => UseGuards(new AuthGuard(verifyFirebaseJwt));

--- a/apps/recnet-api/src/utils/auth/auth.guard.ts
+++ b/apps/recnet-api/src/utils/auth/auth.guard.ts
@@ -8,14 +8,11 @@ import { Request } from "express";
 
 import { getPublicKey } from "@recnet/recnet-jwt";
 
-import { JwtPayloadSchema, VerifyJwtFunction } from "./auth.type";
+import { VerifyJwtFunction } from "./auth.type";
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(
-    private readonly verifyJwt: VerifyJwtFunction,
-    private readonly payloadSchema: JwtPayloadSchema
-  ) {}
+  constructor(private readonly verifyJwt: VerifyJwtFunction) {}
 
   async canActivate(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();

--- a/apps/recnet-api/src/utils/auth/auth.type.ts
+++ b/apps/recnet-api/src/utils/auth/auth.type.ts
@@ -1,7 +1,5 @@
 import {
   RecNetJwtPayload,
-  firebaseJwtPayloadSchema,
-  recnetJwtPayloadSchema,
   verifyFirebaseJwt,
   verifyRecnetJwt,
 } from "@recnet/recnet-jwt";
@@ -9,10 +7,6 @@ import {
 export type VerifyJwtFunction =
   | typeof verifyFirebaseJwt
   | typeof verifyRecnetJwt;
-
-export type JwtPayloadSchema =
-  | typeof firebaseJwtPayloadSchema
-  | typeof recnetJwtPayloadSchema;
 
 export type RecNetJwtPayloadProps = keyof RecNetJwtPayload["recnet"];
 

--- a/apps/recnet-api/src/utils/auth/auth.user.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.user.decorator.ts
@@ -24,7 +24,7 @@ export const User = createParamDecorator<
       "Invalid JWT payload"
     );
   }
-  const recnetUser = recnetJwtPayload.data;
+  const recnetUser = recnetJwtPayload.data.recnet;
 
   return prop ? recnetUser[prop] : recnetUser;
 });

--- a/apps/recnet-api/src/utils/auth/role.guard.ts
+++ b/apps/recnet-api/src/utils/auth/role.guard.ts
@@ -1,0 +1,40 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpStatus,
+  UnauthorizedException,
+  mixin,
+} from "@nestjs/common";
+
+import { recnetJwtPayloadSchema } from "@recnet/recnet-jwt";
+
+import { UserRole } from "@recnet/recnet-api-model";
+
+import { RecnetError } from "../error/recnet.error";
+import { ErrorCode } from "../error/recnet.error.const";
+
+export const RoleGuard = (allowedRoles?: UserRole[]) => {
+  class RoleGuardMixin implements CanActivate {
+    canActivate(context: ExecutionContext) {
+      const request = context.switchToHttp().getRequest();
+      const recnetJwtPayload = recnetJwtPayloadSchema.safeParse(request.user);
+      if (!recnetJwtPayload.success) {
+        throw new RecnetError(
+          ErrorCode.ZOD_VALIDATION_ERROR,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          recnetJwtPayload.error.message
+        );
+      }
+
+      const role = recnetJwtPayload.data.recnet.role;
+      if (allowedRoles && !allowedRoles.includes(role)) {
+        throw new UnauthorizedException();
+      }
+
+      return true;
+    }
+  }
+
+  const guard = mixin(RoleGuardMixin);
+  return guard;
+};

--- a/libs/recnet-api-model/src/lib/api/admin.ts
+++ b/libs/recnet-api-model/src/lib/api/admin.ts
@@ -35,3 +35,10 @@ export const postInviteCodesRequestSchema = z.object({
 export type PostInviteCodesRequest = z.infer<
   typeof postInviteCodesRequestSchema
 >;
+
+export const postInviteCodesResponseSchema = z.object({
+  codes: z.array(z.string()),
+});
+export type PostInviteCodesResponse = z.infer<
+  typeof postInviteCodesResponseSchema
+>;

--- a/libs/recnet-api-model/src/lib/api/admin.ts
+++ b/libs/recnet-api-model/src/lib/api/admin.ts
@@ -6,7 +6,7 @@ import { inviteCodeSchema } from "../model";
 export const getStatsResponseSchema = z.object({
   numUsers: z.number(),
   numRecs: z.number(),
-  numRecsOverTime: z.record(z.number(), z.number()),
+  numRecsOverTime: z.record(z.string(), z.number()),
   numUpcomingRecs: z.number(),
 });
 export type GetStatsResponse = z.infer<typeof getStatsResponseSchema>;

--- a/libs/recnet-api-model/src/lib/api/admin.ts
+++ b/libs/recnet-api-model/src/lib/api/admin.ts
@@ -29,7 +29,7 @@ export type GetInviteCodesResponse = z.infer<
 
 // POST /inviteCodes
 export const postInviteCodesRequestSchema = z.object({
-  numCodes: z.number(),
+  numCodes: z.number().min(1).max(20),
   ownerId: z.string(),
 });
 export type PostInviteCodesRequest = z.infer<


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Invite Code API
- Stats API (used in admin panel, e.g. get user count, rec count, ...)
- Extend `Auth` decorator. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
Now we can passed in allowed roles (`UserRole[]`) in `Auth` decorator like this. If not specified any role, the decorator won't check the role of the user. 
![Screenshot 2024-04-01 at 4 52 17 PM](https://github.com/lil-lab/recnet/assets/71842426/9838bc28-3db9-42a4-88d3-7bcc395d7134)

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
