### PR TITLE
[recnet-api] Change the cron to utc timezone

### DIFF
--- a/apps/recnet-api/src/modules/email/email.const.ts
+++ b/apps/recnet-api/src/modules/email/email.const.ts
@@ -1,6 +1,6 @@
 export const MAX_REC_PER_MAIL = 5;
 
-export const WEEKLY_DIGEST_CRON = "59 40 15 * * 6";
+export const WEEKLY_DIGEST_CRON = "59 10 20 * * 6";
 
 // providers
 export const MAIL_TRANSPORTER = "MAIL_TRANSPORTER";

--- a/apps/recnet-api/src/modules/email/email.controller.ts
+++ b/apps/recnet-api/src/modules/email/email.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, HttpStatus, Inject, Post } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
-import { ApiCreatedResponse, ApiOperation } from "@nestjs/swagger";
+import { ApiCreatedResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { AppConfig } from "@recnet-api/config/common.config";
 import { RecnetError } from "@recnet-api/utils/error/recnet.error";
@@ -8,6 +8,7 @@ import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
 
 import { EmailService } from "./email.service";
 
+@ApiTags("mail")
 @Controller("mail")
 export class EmailController {
   constructor(

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -43,7 +43,7 @@ export class EmailService {
     private readonly weeklyDigestCronLogRepository: WeeklyDigestCronLogRepository
   ) {}
 
-  @Cron(WEEKLY_DIGEST_CRON)
+  @Cron(WEEKLY_DIGEST_CRON, { utcOffset: 0 })
   public async weeklyDigestCron(): Promise<void> {
     const logger = new Logger("WeeklyDigestCron");
 


### PR DESCRIPTION
## Description

Change the cron to utc timezone

## Related Issue

https://github.com/lil-lab/recnet/pull/204
https://github.com/lil-lab/recnet/issues/171

## Notes

Will change the `WEEKLY_DIGEST_CRON` to `59 59 23 * * 2` if this works on dev.

## TODO

- [ ] Paste the testing link
- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
