### PR TITLE
[recnet-api] Add email retry

### DIFF
--- a/apps/recnet-api/src/modules/email/email.const.ts
+++ b/apps/recnet-api/src/modules/email/email.const.ts
@@ -4,5 +4,7 @@ export const WEEKLY_DIGEST_CRON = "0 0 0 * * 3";
 
 export const RETRY_LIMIT = 3;
 
+export const SLEEP_DURATION_MS = 1000;
+
 // providers
 export const MAIL_TRANSPORTER = "MAIL_TRANSPORTER";

--- a/apps/recnet-api/src/modules/email/email.const.ts
+++ b/apps/recnet-api/src/modules/email/email.const.ts
@@ -2,5 +2,7 @@ export const MAX_REC_PER_MAIL = 5;
 
 export const WEEKLY_DIGEST_CRON = "0 0 0 * * 3";
 
+export const RETRY_LIMIT = 3;
+
 // providers
 export const MAIL_TRANSPORTER = "MAIL_TRANSPORTER";

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -22,6 +22,7 @@ import { getLatestCutOff } from "@recnet/recnet-date-fns";
 import {
   MAIL_TRANSPORTER,
   MAX_REC_PER_MAIL,
+  SLEEP_DURATION_MS,
   WEEKLY_DIGEST_CRON,
 } from "./email.const";
 import { SendMailResult, Transporter } from "./email.type";
@@ -62,7 +63,9 @@ export class EmailService {
       for (const user of users) {
         const result = await this.sendWeeklyDigest(user, cutoff);
         results.push(result);
-        await sleep(1000); // Sleep for 1 second
+
+        // avoid rate limit
+        await sleep(SLEEP_DURATION_MS);
       }
 
       const successCount = results.filter(

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -15,6 +15,7 @@ import UserRepository from "@recnet-api/database/repository/user.repository";
 import { User as DbUser } from "@recnet-api/database/repository/user.repository.type";
 import WeeklyDigestCronLogRepository from "@recnet-api/database/repository/weekly-digest-cron-log.repository";
 import { Rec } from "@recnet-api/modules/rec/entities/rec.entity";
+import { sleep } from "@recnet-api/utils";
 
 import { getLatestCutOff } from "@recnet/recnet-date-fns";
 
@@ -61,7 +62,7 @@ export class EmailService {
       for (const user of users) {
         const result = await this.sendWeeklyDigest(user, cutoff);
         results.push(result);
-        await new Promise((resolve) => setTimeout(resolve, 1000)); // Sleep for 1 second
+        await sleep(1000); // Sleep for 1 second
       }
 
       const successCount = results.filter(

--- a/apps/recnet-api/src/modules/email/transporters/email.dev.transporters.ts
+++ b/apps/recnet-api/src/modules/email/transporters/email.dev.transporters.ts
@@ -8,6 +8,7 @@ import { sleep } from "@recnet-api/utils";
 import { RecnetError } from "@recnet-api/utils/error/recnet.error";
 import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
 
+import { SLEEP_DURATION_MS } from "../email.const";
 import { SendMailResult } from "../email.type";
 
 const devHandleWhitelist = ["joannechen1223", "swh00tw"];
@@ -51,8 +52,8 @@ class EmailDevTransporter {
           `[Attempt ${retryCount}] Failed to send email ${user.id}: ${error}`
         );
 
-        // sleep for 1 second before retry
-        await sleep(1000);
+        // avoid rate limit
+        await sleep(SLEEP_DURATION_MS);
       }
     }
 

--- a/apps/recnet-api/src/modules/email/transporters/email.dev.transporters.ts
+++ b/apps/recnet-api/src/modules/email/transporters/email.dev.transporters.ts
@@ -48,7 +48,7 @@ class EmailDevTransporter {
       } catch (error) {
         retryCount++;
         this.logger.error(
-          `[Attempt ${retryCount}] Failed to send weekly digest email ${user.id}: ${error}`
+          `[Attempt ${retryCount}] Failed to send email ${user.id}: ${error}`
         );
 
         // sleep for 1 second before retry
@@ -60,7 +60,7 @@ class EmailDevTransporter {
     throw new RecnetError(
       ErrorCode.EMAIL_SEND_ERROR,
       HttpStatus.INTERNAL_SERVER_ERROR,
-      `Failed to send weekly digest email ${mailOptions.to}`
+      `Failed to send email ${mailOptions.to}`
     );
   }
 }

--- a/apps/recnet-api/src/modules/email/transporters/email.transporters.ts
+++ b/apps/recnet-api/src/modules/email/transporters/email.transporters.ts
@@ -8,7 +8,7 @@ import { sleep } from "@recnet-api/utils";
 import { RecnetError } from "@recnet-api/utils/error/recnet.error";
 import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
 
-import { RETRY_LIMIT } from "../email.const";
+import { RETRY_LIMIT, SLEEP_DURATION_MS } from "../email.const";
 import { SendMailResult } from "../email.type";
 
 @Injectable()
@@ -46,8 +46,8 @@ class EmailTransporter {
           `[Attempt ${retryCount}] Failed to send email ${user.id}: ${error}`
         );
 
-        // sleep for 1 second before retry
-        await sleep(1000);
+        // avoid rate limit
+        await sleep(SLEEP_DURATION_MS);
       }
     }
 

--- a/apps/recnet-api/src/modules/email/transporters/email.transporters.ts
+++ b/apps/recnet-api/src/modules/email/transporters/email.transporters.ts
@@ -43,7 +43,7 @@ class EmailTransporter {
       } catch (error) {
         retryCount++;
         this.logger.error(
-          `[Attempt ${retryCount}] Failed to send weekly digest email ${user.id}: ${error}`
+          `[Attempt ${retryCount}] Failed to send email ${user.id}: ${error}`
         );
 
         // sleep for 1 second before retry
@@ -55,7 +55,7 @@ class EmailTransporter {
     throw new RecnetError(
       ErrorCode.EMAIL_SEND_ERROR,
       HttpStatus.INTERNAL_SERVER_ERROR,
-      `Failed to send weekly digest email ${mailOptions.to}`
+      `Failed to send email ${mailOptions.to}`
     );
   }
 }

--- a/apps/recnet-api/src/utils/index.ts
+++ b/apps/recnet-api/src/utils/index.ts
@@ -1,2 +1,5 @@
 export const getOffset = (page: number, pageSize: number): number =>
   (page - 1) * pageSize;
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Description

Add email retry and set the retry limit to 3.

## Related Issue

- https://github.com/lil-lab/recnet/issues/223

## Notes

<!-- Other thing to say -->
N/A

## TODO

- [ ] Paste the testing link
- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
