### PR TITLE
[recnet-api-model] Reorganize api model by features

### DIFF
--- a/libs/recnet-api-model/src/index.ts
+++ b/libs/recnet-api-model/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./lib/model";
-export * from "./lib/api/admin";
 export * from "./lib/api/rec";
 export * from "./lib/api/user";
+export * from "./lib/api/stat";
+export * from "./lib/api/invite-code";
+export * from "./lib/api/article";

--- a/libs/recnet-api-model/src/lib/api/article.ts
+++ b/libs/recnet-api-model/src/lib/api/article.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+import { articleSchema } from "../model";
+
+// GET /articles
+export const getArticlesParamsSchema = z.object({
+  link: z.string().url(),
+});
+export type GetArticlesParams = z.infer<typeof getArticlesParamsSchema>;
+
+export const getArticlesResponseSchema = z.object({
+  article: articleSchema.nullable(),
+});
+export type GetArticlesResponse = z.infer<typeof getArticlesResponseSchema>;

--- a/libs/recnet-api-model/src/lib/api/invite-code.ts
+++ b/libs/recnet-api-model/src/lib/api/invite-code.ts
@@ -2,15 +2,6 @@ import { z } from "zod";
 
 import { inviteCodeSchema } from "../model";
 
-// GET /stats
-export const getStatsResponseSchema = z.object({
-  numUsers: z.number(),
-  numRecs: z.number(),
-  numRecsOverTime: z.record(z.string(), z.number()),
-  numUpcomingRecs: z.number(),
-});
-export type GetStatsResponse = z.infer<typeof getStatsResponseSchema>;
-
 // GET /invite-codes
 export const getInviteCodesParamsSchema = z.object({
   page: z.coerce.number(),

--- a/libs/recnet-api-model/src/lib/api/rec.ts
+++ b/libs/recnet-api-model/src/lib/api/rec.ts
@@ -80,14 +80,3 @@ export const patchRecsUpcomingResponseSchema = z.object({
 export type PatchRecsUpcomingResponse = z.infer<
   typeof patchRecsUpcomingResponseSchema
 >;
-
-// GET /articles
-export const getArticlesParamsSchema = z.object({
-  link: z.string().url(),
-});
-export type GetArticlesParams = z.infer<typeof getArticlesParamsSchema>;
-
-export const getArticlesResponseSchema = z.object({
-  article: articleSchema.nullable(),
-});
-export type GetArticlesResponse = z.infer<typeof getArticlesResponseSchema>;

--- a/libs/recnet-api-model/src/lib/api/stat.ts
+++ b/libs/recnet-api-model/src/lib/api/stat.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+// GET /stats
+export const getStatsResponseSchema = z.object({
+  numUsers: z.number(),
+  numRecs: z.number(),
+  numRecsOverTime: z.record(z.string(), z.number()),
+  numUpcomingRecs: z.number(),
+});
+export type GetStatsResponse = z.infer<typeof getStatsResponseSchema>;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Reorganize api model interfaces by features. Previously, there's a `admin.ts` file inside `recnet-api-model`, however, it's unclear what's inside this file. It's better to separate api interfaces by features strictly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

Note that, although reorganizing these api model files to dedicated files, apps like `recnet` and `recnet-api` don't need to change import path since the interfaces are all barral exported from `libs/recnet-api-model/src/index.ts`.

## TODO

- [ ] Paste the testing link
- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
