### PR TITLE
[recnet-web] fix: hide invite code popover when not logged in

### DIFF
--- a/apps/recnet/CHANGELOG.md
+++ b/apps/recnet/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.7.1](https://github.com/lil-lab/recnet/compare/recnet-web-v1.7.0...recnet-web-v1.7.1) (2024-05-10)
+
+
+### Bug Fixes
+
+* hide invite code popover when not logged in ([2f905d2](https://github.com/lil-lab/recnet/commit/2f905d29369a65bba25e03b0eb187ae09a5045d8))
+
 ## [1.7.0](https://github.com/lil-lab/recnet/compare/recnet-web-v1.6.0...recnet-web-v1.7.0) (2024-05-09)
 
 ### Features

--- a/apps/recnet/package.json
+++ b/apps/recnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recnet",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "commit-and-tag-version": {
     "skip": {
       "commit": true

--- a/apps/recnet/src/app/MobileNavigator.tsx
+++ b/apps/recnet/src/app/MobileNavigator.tsx
@@ -193,15 +193,17 @@ function MobileNavigator() {
         }}
       />
 
-      <InviteCodePopover
-        renderTrigger={(unusedCodes) => {
-          return <Link2Icon width="24" height="24" />;
-        }}
-        popoverContentProps={{
-          side: "top",
-          width: "350px",
-        }}
-      />
+      {user ? (
+        <InviteCodePopover
+          renderTrigger={(unusedCodes) => {
+            return <Link2Icon width="24" height="24" />;
+          }}
+          popoverContentProps={{
+            side: "top",
+            width: "350px",
+          }}
+        />
+      ) : null}
 
       <Dialog.Root
         open={open}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Hide Invite code popover on mobile when unauthenticated. Currently, when logged out, the invite code popover's trigger is still there on navigation bar.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## TODO

- [x] Paste the testing link: [rec-net-git-fix-hide-invite-code-popover-recnet-542617e7.vercel.app](https://rec-net-git-fix-hide-invite-code-popover-recnet-542617e7.vercel.app/)
- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
