### PR TITLE
[recnet-api] Add url and recommendation numbers to user preview

### DIFF
--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -10,7 +10,9 @@ export const userPreview = Prisma.validator<Prisma.UserDefaultArgs>()({
     photoUrl: true,
     affiliation: true,
     bio: true,
+    url: true,
     followedBy: true,
+    recommendations: true,
   },
 });
 
@@ -32,6 +34,7 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
     email: true,
     role: true,
     following: true,
+    recommendations: true,
   },
 });
 

--- a/apps/recnet-api/src/modules/announcement/announcement.service.ts
+++ b/apps/recnet-api/src/modules/announcement/announcement.service.ts
@@ -14,6 +14,8 @@ import { CreateAnnouncementDto } from "./dto/create.announcement.dto";
 import { UpdateAnnouncementDto } from "./dto/update.announcement.dto";
 import { Announcement } from "./entities/announcement.entity";
 
+import { transformUserPreview } from "../user/user.transformer";
+
 @Injectable()
 export class AnnouncementService {
   constructor(
@@ -102,17 +104,7 @@ export class AnnouncementService {
 
   private transformAnnouncement(dbAnnouncement: DbAnnouncement): Announcement {
     const { createdBy } = dbAnnouncement;
-    const createdByUserPreview = {
-      id: createdBy.id,
-      handle: createdBy.handle,
-      displayName: createdBy.displayName,
-      photoUrl: createdBy.photoUrl,
-      affiliation: createdBy.affiliation,
-      bio: createdBy.bio,
-      url: createdBy.url,
-      numFollowers: createdBy.followedBy.length,
-      numRecs: createdBy.recommendations.length,
-    };
+    const createdByUserPreview = transformUserPreview(createdBy);
     return {
       id: dbAnnouncement.id,
       title: dbAnnouncement.title,

--- a/apps/recnet-api/src/modules/announcement/announcement.service.ts
+++ b/apps/recnet-api/src/modules/announcement/announcement.service.ts
@@ -109,7 +109,9 @@ export class AnnouncementService {
       photoUrl: createdBy.photoUrl,
       affiliation: createdBy.affiliation,
       bio: createdBy.bio,
+      url: createdBy.url,
       numFollowers: createdBy.followedBy.length,
+      numRecs: createdBy.recommendations.length,
     };
     return {
       id: dbAnnouncement.id,

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -166,7 +166,9 @@ export class EmailService {
         photoUrl: dbRec.user.photoUrl,
         affiliation: dbRec.user.affiliation,
         bio: dbRec.user.bio,
+        url: dbRec.user.url,
         numFollowers: dbRec.user.followedBy.length,
+        numRecs: dbRec.user.recommendations.length,
       },
     };
   }

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -28,6 +28,8 @@ import {
 import { SendMailResult, Transporter } from "./email.type";
 import WeeklyDigest, { WeeklyDigestSubject } from "./templates/WeeklyDigest";
 
+import { transformUserPreview } from "../user/user.transformer";
+
 @Injectable()
 export class EmailService {
   constructor(
@@ -159,17 +161,7 @@ export class EmailService {
     return {
       ...dbRec,
       cutoff: dbRec.cutoff.toISOString(),
-      user: {
-        id: dbRec.user.id,
-        handle: dbRec.user.handle,
-        displayName: dbRec.user.displayName,
-        photoUrl: dbRec.user.photoUrl,
-        affiliation: dbRec.user.affiliation,
-        bio: dbRec.user.bio,
-        url: dbRec.user.url,
-        numFollowers: dbRec.user.followedBy.length,
-        numRecs: dbRec.user.recommendations.length,
-      },
+      user: transformUserPreview(dbRec.user),
     };
   }
 }

--- a/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
@@ -15,6 +15,8 @@ import {
   GetAllInviteCodeResponse,
 } from "./invite-code.response";
 
+import { transformUserPreview } from "../user/user.transformer";
+
 @Injectable()
 export class InviteCodeService {
   constructor(
@@ -102,31 +104,11 @@ export class InviteCodeService {
     return {
       id: dbInviteCode.id,
       code: dbInviteCode.code,
-      owner: {
-        id: dbInviteCode.owner.id,
-        handle: dbInviteCode.owner.handle,
-        displayName: dbInviteCode.owner.displayName,
-        photoUrl: dbInviteCode.owner.photoUrl,
-        affiliation: dbInviteCode.owner.affiliation,
-        bio: dbInviteCode.owner.bio,
-        url: dbInviteCode.owner.url,
-        numFollowers: dbInviteCode.owner.followedBy.length,
-        numRecs: dbInviteCode.owner.recommendations.length,
-      },
+      owner: transformUserPreview(dbInviteCode.owner),
       issuedAt: dbInviteCode.issuedAt,
       usedAt: dbInviteCode.usedAt,
       usedBy: dbInviteCode.usedBy
-        ? {
-            id: dbInviteCode.usedBy.id,
-            handle: dbInviteCode.usedBy.handle,
-            displayName: dbInviteCode.usedBy.displayName,
-            photoUrl: dbInviteCode.usedBy.photoUrl,
-            affiliation: dbInviteCode.usedBy.affiliation,
-            bio: dbInviteCode.usedBy.bio,
-            url: dbInviteCode.usedBy.url,
-            numFollowers: dbInviteCode.usedBy.followedBy.length,
-            numRecs: dbInviteCode.usedBy.recommendations.length,
-          }
+        ? transformUserPreview(dbInviteCode.usedBy)
         : null,
     };
   }

--- a/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.service.ts
@@ -109,7 +109,9 @@ export class InviteCodeService {
         photoUrl: dbInviteCode.owner.photoUrl,
         affiliation: dbInviteCode.owner.affiliation,
         bio: dbInviteCode.owner.bio,
+        url: dbInviteCode.owner.url,
         numFollowers: dbInviteCode.owner.followedBy.length,
+        numRecs: dbInviteCode.owner.recommendations.length,
       },
       issuedAt: dbInviteCode.issuedAt,
       usedAt: dbInviteCode.usedAt,
@@ -121,7 +123,9 @@ export class InviteCodeService {
             photoUrl: dbInviteCode.usedBy.photoUrl,
             affiliation: dbInviteCode.usedBy.affiliation,
             bio: dbInviteCode.usedBy.bio,
+            url: dbInviteCode.usedBy.url,
             numFollowers: dbInviteCode.usedBy.followedBy.length,
+            numRecs: dbInviteCode.usedBy.recommendations.length,
           }
         : null,
     };

--- a/apps/recnet-api/src/modules/rec/rec.service.ts
+++ b/apps/recnet-api/src/modules/rec/rec.service.ts
@@ -23,6 +23,8 @@ import {
   UpdateRecResponse,
 } from "./rec.response";
 
+import { transformUserPreview } from "../user/user.transformer";
+
 @Injectable()
 export class RecService {
   constructor(
@@ -192,17 +194,7 @@ export class RecService {
     return {
       ...dbRec,
       cutoff: dbRec.cutoff.toISOString(),
-      user: {
-        id: dbRec.user.id,
-        handle: dbRec.user.handle,
-        displayName: dbRec.user.displayName,
-        photoUrl: dbRec.user.photoUrl,
-        affiliation: dbRec.user.affiliation,
-        bio: dbRec.user.bio,
-        url: dbRec.user.url,
-        numFollowers: dbRec.user.followedBy.length,
-        numRecs: dbRec.user.recommendations.length,
-      },
+      user: transformUserPreview(dbRec.user),
     };
   }
 

--- a/apps/recnet-api/src/modules/rec/rec.service.ts
+++ b/apps/recnet-api/src/modules/rec/rec.service.ts
@@ -199,7 +199,9 @@ export class RecService {
         photoUrl: dbRec.user.photoUrl,
         affiliation: dbRec.user.affiliation,
         bio: dbRec.user.bio,
+        url: dbRec.user.url,
         numFollowers: dbRec.user.followedBy.length,
+        numRecs: dbRec.user.recommendations.length,
       },
     };
   }

--- a/apps/recnet-api/src/modules/user/entities/user.entity.ts
+++ b/apps/recnet-api/src/modules/user/entities/user.entity.ts
@@ -39,6 +39,9 @@ export class User {
   numFollowers: number;
 
   @ApiProperty()
+  numRecs: number;
+
+  @ApiProperty()
   email: string;
 
   @ApiProperty()

--- a/apps/recnet-api/src/modules/user/entities/user.preview.entity.ts
+++ b/apps/recnet-api/src/modules/user/entities/user.preview.entity.ts
@@ -19,6 +19,12 @@ export class UserPreview {
   @ApiPropertyOptional()
   bio: string | null;
 
+  @ApiPropertyOptional()
+  url: string | null;
+
   @ApiProperty()
   numFollowers: number;
+
+  @ApiProperty()
+  numRecs: number;
 }

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -162,6 +162,7 @@ export class UserService {
       semanticScholarLink: user.semanticScholarLink,
       openReviewUserName: user.openReviewUserName,
       numFollowers: user.followedBy.length,
+      numRecs: user.recommendations.length,
       email: user.email,
       role: user.role,
       following: followingUsers,
@@ -176,7 +177,9 @@ export class UserService {
       photoUrl: user.photoUrl,
       affiliation: user.affiliation,
       bio: user.bio,
+      url: user.url,
       numFollowers: user.followedBy.length,
+      numRecs: user.recommendations.length,
     };
   }
 }

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -21,6 +21,7 @@ import { UpdateUserDto } from "./dto/update.user.dto";
 import { User } from "./entities/user.entity";
 import { UserPreview } from "./entities/user.preview.entity";
 import { GetUsersResponse } from "./user.response";
+import { transformUserPreview } from "./user.transformer";
 
 @Injectable()
 export class UserService {
@@ -44,7 +45,7 @@ export class UserService {
       pageSize,
       filter
     );
-    const userPreviews: UserPreview[] = users.map(this.transformUserPreview);
+    const userPreviews: UserPreview[] = users.map(transformUserPreview);
 
     return {
       hasNext: users.length + getOffset(page, pageSize) < usersCount,
@@ -148,7 +149,7 @@ export class UserService {
 
     const followingUsers: UserPreview[] = (
       await this.userRepository.findUserPreviewByIds(followingUserIds)
-    ).map(this.transformUserPreview);
+    ).map(transformUserPreview);
 
     return {
       id: user.id,
@@ -166,20 +167,6 @@ export class UserService {
       email: user.email,
       role: user.role,
       following: followingUsers,
-    };
-  }
-
-  private transformUserPreview(user: DbUserPreview): UserPreview {
-    return {
-      id: user.id,
-      handle: user.handle,
-      displayName: user.displayName,
-      photoUrl: user.photoUrl,
-      affiliation: user.affiliation,
-      bio: user.bio,
-      url: user.url,
-      numFollowers: user.followedBy.length,
-      numRecs: user.recommendations.length,
     };
   }
 }

--- a/apps/recnet-api/src/modules/user/user.transformer.ts
+++ b/apps/recnet-api/src/modules/user/user.transformer.ts
@@ -1,0 +1,15 @@
+import { UserPreview as DbUserPreview } from "@recnet-api/database/repository/user.repository.type";
+
+import { UserPreview } from "./entities/user.preview.entity";
+
+export const transformUserPreview = (user: DbUserPreview): UserPreview => ({
+  id: user.id,
+  handle: user.handle,
+  displayName: user.displayName,
+  photoUrl: user.photoUrl,
+  affiliation: user.affiliation,
+  bio: user.bio,
+  url: user.url,
+  numFollowers: user.followedBy.length,
+  numRecs: user.recommendations.length,
+});

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -35,6 +35,7 @@ export const patchUserMeRequestSchema = userSchema
   .omit({
     id: true,
     numFollowers: true,
+    numRecs: true,
     following: true,
     role: true,
   })
@@ -51,10 +52,10 @@ export const postUserMeRequestSchema = userPreviewSchema
   .omit({
     id: true,
     numFollowers: true,
+    numRecs: true,
   })
   .extend({
     email: z.string(),
-    url: z.string().url().nullable(),
     googleScholarLink: z.string().url().nullable(),
     semanticScholarLink: z.string().url().nullable(),
     openReviewUserName: z.string().nullable(),

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -12,14 +12,15 @@ export const userPreviewSchema = z.object({
   photoUrl: z.string().url(),
   affiliation: z.string().nullable(),
   bio: z.string().nullable(),
+  url: z.string().url().nullable(),
   numFollowers: z.number(),
+  numRecs: z.number(),
 });
 export type UserPreview = z.infer<typeof userPreviewSchema>;
 
 export const userSchema = userPreviewSchema.extend({
   email: z.string().email(),
   role: userRoleSchema,
-  url: z.string().url().nullable(),
   googleScholarLink: z.string().url().nullable(),
   semanticScholarLink: z.string().url().nullable(),
   openReviewUserName: z.string().nullable(),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Add `url` and `numRecs` to userPreview.
- Refactor: Extract userPreview transformer

## Related Issue

- https://github.com/lil-lab/recnet/issues/99
- https://github.com/lil-lab/recnet/issues/129

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## TODO

- [ ] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
