### PR TITLE
[recnet-web][v1.9.1] Add announcement link to mobile admin menu

### DIFF
--- a/apps/recnet/CHANGELOG.md
+++ b/apps/recnet/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.9.1](https://github.com/lil-lab/recnet/compare/recnet-web-v1.9.0...recnet-web-v1.9.1) (2024-05-21)
+
+
+### Bug Fixes
+
+* add inapp announcement page to mobile admin menu ([351d026](https://github.com/lil-lab/recnet/commit/351d0260cd0a4c002f44e573153985491c9c8c99))
+
 ## [1.9.0](https://github.com/lil-lab/recnet/compare/recnet-web-v1.8.0...recnet-web-v1.9.0) (2024-05-19)
 
 ### Features

--- a/apps/recnet/package.json
+++ b/apps/recnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recnet",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "commit-and-tag-version": {
     "skip": {
       "commit": true

--- a/apps/recnet/src/app/Footer.tsx
+++ b/apps/recnet/src/app/Footer.tsx
@@ -46,7 +46,7 @@ function Footer() {
         "mb-4 sm:mb-0"
       )}
     >
-      <Flex gap="4" className="mr-auto">
+      <Flex gap="4" className="sm:mr-auto">
         <Tooltip content="Click to view changelogs">
           <Link href="https://github.com/lil-lab/recnet/blob/master/apps/recnet/CHANGELOG.md">
             <Flex gap="1" className="items-center">
@@ -73,7 +73,7 @@ function Footer() {
         </Flex>
       </Flex>
       <Text size="1">© 2024 RecNet. All rights reserved.</Text>
-      <Flex gap="2" className="items-center ml-auto">
+      <Flex gap="2" className="items-center sm:ml-auto">
         {theme && mounted ? (
           <DropdownMenu.Root>
             <DropdownMenu.Trigger className="cursor-pointer">

--- a/apps/recnet/src/app/MobileNavigator.tsx
+++ b/apps/recnet/src/app/MobileNavigator.tsx
@@ -130,9 +130,12 @@ function AdminDropdown(props: { children: React.ReactNode }) {
           <Link href={`/admin/stats/user-rec`}>User & Rec</Link>
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <div className={cn(dropdownSectionStyle)}>Email</div>
+        <div className={cn(dropdownSectionStyle)}>Announcement</div>
         <DropdownMenu.Item>
-          <Link href={`/admin`}>🚧 Announcement</Link>
+          <Link href={`/admin/announcement/email`}>🚧 Email</Link>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <Link href={`/admin/announcement/inapp`}>In-app</Link>
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
         <div className={cn(dropdownSectionStyle)}>Invite Codes</div>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The In-app announcement page is missed at mobile's admin menu. 

![Screenshot 2024-05-20 at 9 35 13 PM](https://github.com/lil-lab/recnet/assets/71842426/62598b05-500f-44b1-9b3b-02ed3eaac531)

Update the menu in this PR.

![Screenshot 2024-05-20 at 9 35 58 PM](https://github.com/lil-lab/recnet/assets/71842426/dcff2f6e-cf84-4387-8ea3-44f9b5a1064b)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
