### PR TITLE
fix: upcoming rec appear in profile

### DIFF
--- a/apps/recnet-api/src/database/repository/rec.repository.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.ts
@@ -1,10 +1,12 @@
-import { Injectable } from "@nestjs/common";
+import { HttpStatus, Injectable } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
 
 import PrismaConnectionProvider from "@recnet-api/database/prisma/prisma.connection.provider";
 import { rec, Rec } from "@recnet-api/database/repository/rec.repository.type";
 import { RecFilterBy } from "@recnet-api/database/repository/rec.repository.type";
 import { getOffset } from "@recnet-api/utils";
+import { RecnetError } from "@recnet-api/utils/error/recnet.error";
+import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
 
 import { getNextCutOff } from "@recnet/recnet-date-fns";
 
@@ -128,9 +130,19 @@ export default class RecRepository {
     if (filter.userIds) {
       where.userId = { in: filter.userIds };
     }
-    if (filter.cutoff) {
+
+    if (filter.cutoff && filter.excludeCutoff) {
+      throw new RecnetError(
+        ErrorCode.INTERNAL_SERVER_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "Both cutoff and excludeCutoff cannot be used together."
+      );
+    } else if (filter.cutoff) {
       where.cutoff = filter.cutoff;
+    } else if (filter.excludeCutoff) {
+      where.cutoff = { not: filter.excludeCutoff };
     }
+
     return where;
   }
 }

--- a/apps/recnet-api/src/database/repository/rec.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.type.ts
@@ -21,5 +21,8 @@ export type Rec = Prisma.RecommendationGetPayload<typeof rec>;
 export type RecFilterBy = {
   userId?: string;
   userIds?: string[];
+
+  // Both cutoff and excludeCutoff cannot be used together.
   cutoff?: Date;
+  excludeCutoff?: Date;
 };

--- a/apps/recnet-api/src/modules/rec/rec.controller.ts
+++ b/apps/recnet-api/src/modules/rec/rec.controller.ts
@@ -25,7 +25,7 @@ import {
   ZodValidationQueryPipe,
 } from "@recnet-api/utils/pipes/zod.validation.pipe";
 
-import { getLatestCutOff } from "@recnet/recnet-date-fns";
+import { getLatestCutOff, getNextCutOff } from "@recnet/recnet-date-fns";
 
 import {
   getRecsFeedsParamsSchema,
@@ -63,7 +63,10 @@ export class RecController {
   @UsePipes(new ZodValidationQueryPipe(getRecsParamsSchema))
   public async getRecs(@Query() dto: QueryRecsDto): Promise<GetRecsResponse> {
     const { page, pageSize, userId } = dto;
-    return this.recService.getRecs(page, pageSize, userId);
+
+    // Exclude upcoming rec from showing in user's profile page
+    const excludeCutoff = getNextCutOff();
+    return this.recService.getRecs(page, pageSize, userId, excludeCutoff);
   }
 
   @ApiOperation({

--- a/apps/recnet-api/src/modules/rec/rec.service.ts
+++ b/apps/recnet-api/src/modules/rec/rec.service.ts
@@ -39,10 +39,12 @@ export class RecService {
   public async getRecs(
     page: number,
     pageSize: number,
-    userId: string
+    userId: string,
+    excludeCutoff: Date
   ): Promise<GetRecsResponse> {
     const filter: RecFilterBy = {
       userId: userId,
+      excludeCutoff: excludeCutoff,
     };
     const recCount = await this.recRepository.countRecs(filter);
     const dbRecs = await this.recRepository.findRecs(page, pageSize, filter);


### PR DESCRIPTION
## Description

Fix bug: Recommendation appearing on profile before cutoff.

Add exludeCutoff to RecsFilter and exclude the next cutoff in the `GET /recs` API to avoid current cycle recommendations appearing in user profile pages.

## Related Issue

- https://github.com/lil-lab/recnet/issues/249

## Notes

<!-- Other thing to say -->

## TODO

- [ ] Paste the testing link
- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
