### PR TITLE
[recnet-web][v1.10.1] Resize intro video

### DIFF
--- a/apps/recnet/CHANGELOG.md
+++ b/apps/recnet/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.10.1](https://github.com/lil-lab/recnet/compare/recnet-web-v1.10.0...recnet-web-v1.10.1) (2024-09-03)
+
 ## [1.10.0](https://github.com/lil-lab/recnet/compare/recnet-web-v1.9.3...recnet-web-v1.10.0) (2024-08-29)
 
 

--- a/apps/recnet/package.json
+++ b/apps/recnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recnet",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "commit-and-tag-version": {
     "skip": {
       "commit": true

--- a/apps/recnet/src/app/page.tsx
+++ b/apps/recnet/src/app/page.tsx
@@ -96,7 +96,13 @@ export default async function Home() {
       >
         Receive weekly paper recs from researchers you follow.
       </Text>
-      <div className="w-[90%] sm:w-[55%] flex justify-start mt-6">
+      <div className="flex flex-row gap-x-3 px-3">
+        <LoginButton />
+        <Button size="4" variant="outline" asChild className="cursor-pointer">
+          <Link href="/about">Learn more</Link>
+        </Button>
+      </div>
+      <div className="w-[90%] sm:w-[75%] flex justify-start mt-6">
         <iframe
           src="https://www.youtube.com/embed/Sl7CKRwcX1s?si=IBLh-ibnEFN1lALz"
           title="YouTube video player"
@@ -104,12 +110,6 @@ export default async function Home() {
           allowFullScreen
           className="w-full aspect-[560/315]"
         ></iframe>
-      </div>
-      <div className="flex flex-row gap-x-3 px-3">
-        <LoginButton />
-        <Button size="4" variant="outline" asChild className="cursor-pointer">
-          <Link href="/about">Learn more</Link>
-        </Button>
       </div>
 
       <div


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adjust size of intro video at landing page

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #265 

## Notes

<!-- Other thing to say -->

## TODO

- [x] Paste the testing link:  https://rec-net-git-chore-resize-intro-video-recnet-542617e7.vercel.app/
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
