### PR TITLE
[recnet-api] Deactivate account

### DIFF
--- a/apps/recnet-api/prisma/migrations/20240905002749_add_is_activated_to_user/down.sql
+++ b/apps/recnet-api/prisma/migrations/20240905002749_add_is_activated_to_user/down.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "isActivated";

--- a/apps/recnet-api/prisma/migrations/20240905002749_add_is_activated_to_user/migration.sql
+++ b/apps/recnet-api/prisma/migrations/20240905002749_add_is_activated_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isActivated" BOOLEAN NOT NULL DEFAULT true;

--- a/apps/recnet-api/prisma/schema.prisma
+++ b/apps/recnet-api/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   openReviewUserName  String?    @db.VarChar(64)
   lastLoginAt         DateTime
   role                Role       @default(USER) // Enum type
+  isActivated         Boolean    @default(true)
   createdAt           DateTime   @default(now())
   updatedAt           DateTime   @default(now()) @updatedAt
 

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -124,6 +124,11 @@ export default class UserRepository {
     });
   }
 
+  public async isActivated(userId: string): Promise<boolean> {
+    const user = await this.findUserById(userId);
+    return user.isActivated;
+  }
+
   private transformUserFilterByToPrismaWhere(
     filter: UserFilterBy
   ): Prisma.UserWhereInput {

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -39,6 +39,7 @@ export default class UserRepository {
   public async findAllUsers(): Promise<User[]> {
     return this.prisma.user.findMany({
       select: user.select,
+      where: { isActivated: true },
     });
   }
 
@@ -139,6 +140,8 @@ export default class UserRepository {
         mode: Prisma.QueryMode.insensitive,
       },
     });
+    where.isActivated = true;
+
     if (filter.handle) {
       where.handle = filter.handle;
     }

--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -11,7 +11,11 @@ export const userPreview = Prisma.validator<Prisma.UserDefaultArgs>()({
     affiliation: true,
     bio: true,
     url: true,
-    followedBy: true,
+    followedBy: {
+      where: {
+        followedBy: { isActivated: true },
+      },
+    },
     recommendations: true,
   },
 });
@@ -30,11 +34,19 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
     googleScholarLink: true,
     semanticScholarLink: true,
     openReviewUserName: true,
-    followedBy: true,
+    followedBy: {
+      where: {
+        followedBy: { isActivated: true },
+      },
+    },
     email: true,
     role: true,
     isActivated: true,
-    following: true,
+    following: {
+      where: {
+        following: { isActivated: true },
+      },
+    },
     recommendations: true,
   },
 });

--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -33,6 +33,7 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
     followedBy: true,
     email: true,
     role: true,
+    isActivated: true,
     following: true,
     recommendations: true,
   },

--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -86,4 +86,5 @@ export type UpdateUserInput = {
   semanticScholarLink?: string | null;
   openReviewUserName?: string | null;
   email?: string;
+  isActivated?: boolean;
 };

--- a/apps/recnet-api/src/modules/announcement/announcement.controller.ts
+++ b/apps/recnet-api/src/modules/announcement/announcement.controller.ts
@@ -67,7 +67,7 @@ export class AnnouncementController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: Announcement })
   @Post()
-  @Auth(["ADMIN"])
+  @Auth({ allowedRoles: ["ADMIN"] })
   @UsePipes(new ZodValidationBodyPipe(postAnnouncementsRequestSchema))
   public async createAnnouncement(
     @Body() dto: CreateAnnouncementDto,
@@ -85,7 +85,7 @@ export class AnnouncementController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: Announcement })
   @Patch("/:id")
-  @Auth(["ADMIN"])
+  @Auth({ allowedRoles: ["ADMIN"] })
   @UsePipes(new ZodValidationBodyPipe(patchAnnouncementRequestSchema))
   public async updateAnnouncement(
     @Param("id", ParseIntPipe) id: number,

--- a/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
+++ b/apps/recnet-api/src/modules/invite-code/invite-code.controller.ts
@@ -54,7 +54,7 @@ export class InviteCodeController {
   @ApiOkResponse({ type: CreateInviteCodeResponse })
   @ApiBearerAuth()
   @Post()
-  @Auth(["ADMIN"])
+  @Auth({ allowedRoles: ["ADMIN"] })
   @UsePipes(new ZodValidationBodyPipe(postInviteCodesRequestSchema))
   public async createInviteCode(
     @Body() dto: CreateInviteCodeDto
@@ -74,7 +74,7 @@ export class InviteCodeController {
   @ApiOkResponse({ type: GetAllInviteCodeResponse })
   @ApiBearerAuth()
   @Get("all")
-  @Auth(["ADMIN"])
+  @Auth({ allowedRoles: ["ADMIN"] })
   @UsePipes(new ZodValidationQueryPipe(getInviteCodesAllParamsSchema))
   public async getInviteCodes(
     @Query() dto: QueryAllInviteCodeDto

--- a/apps/recnet-api/src/modules/rec/rec.service.ts
+++ b/apps/recnet-api/src/modules/rec/rec.service.ts
@@ -42,6 +42,15 @@ export class RecService {
     userId: string,
     to: Date
   ): Promise<GetRecsResponse> {
+    // validate if the user exists and is activated
+    const user = await this.userRepository.findUserById(userId);
+    if (!user.isActivated) {
+      throw new RecnetError(
+        ErrorCode.ACCOUNT_NOT_ACTIVATED,
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
     const filter: RecFilterBy = {
       userId: userId,
       cutoff: { to },

--- a/apps/recnet-api/src/modules/stat/stat.controller.ts
+++ b/apps/recnet-api/src/modules/stat/stat.controller.ts
@@ -25,7 +25,7 @@ export class StatController {
   @ApiOkResponse({ type: QueryStatResponse })
   @ApiBearerAuth()
   @Get()
-  @Auth(["ADMIN"])
+  @Auth({ allowedRoles: ["ADMIN"] })
   public async getStats(): Promise<QueryStatResponse> {
     return this.statService.getStats();
   }

--- a/apps/recnet-api/src/modules/user/dto/update.user.dto.ts
+++ b/apps/recnet-api/src/modules/user/dto/update.user.dto.ts
@@ -37,3 +37,8 @@ export class UpdateUserDto {
   @ApiPropertyOptional({ example: "example@cornell.edu" })
   email?: string;
 }
+
+export class UpdateUserActivateDto {
+  @ApiPropertyOptional({ example: true })
+  isActivated: boolean;
+}

--- a/apps/recnet-api/src/modules/user/entities/user.entity.ts
+++ b/apps/recnet-api/src/modules/user/entities/user.entity.ts
@@ -48,5 +48,8 @@ export class User {
   role: UserRole;
 
   @ApiProperty()
+  isActivated: boolean;
+
+  @ApiProperty()
   following: UserPreview[];
 }

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -31,6 +31,7 @@ import {
 import {
   deleteUserFollowParamsSchema,
   getUsersParamsSchema,
+  patchUserMeActivateRequestSchema,
   patchUserMeRequestSchema,
   postUserFollowRequestSchema,
   postUserMeRequestSchema,
@@ -41,7 +42,7 @@ import {
 import { CreateUserDto } from "./dto/create.user.dto";
 import { FollowUserDto, UnfollowUserDto } from "./dto/follow.user.dto";
 import { QueryUsersDto } from "./dto/query.users.dto";
-import { UpdateUserDto } from "./dto/update.user.dto";
+import { UpdateUserActivateDto, UpdateUserDto } from "./dto/update.user.dto";
 import {
   ValidateUserHandleDto,
   ValidateUserInviteCodeDto,
@@ -132,6 +133,27 @@ export class UserController {
   ): Promise<GetUserMeResponse> {
     const { userId } = authUser;
     const user = await this.userService.updateUser(userId, dto);
+    return { user };
+  }
+
+  @ApiOperation({
+    summary: "Update my activation status",
+    description: "Update the current user's activation status.",
+  })
+  @ApiOkResponse({ type: GetUserMeResponse })
+  @ApiBearerAuth()
+  @Patch("/me/activate")
+  @UsePipes(new ZodValidationBodyPipe(patchUserMeActivateRequestSchema))
+  @Auth({ allowNonActivated: true })
+  public async updateMyActivationStatus(
+    @User() authUser: AuthUser,
+    @Body() dto: UpdateUserActivateDto
+  ): Promise<GetUserMeResponse> {
+    const { userId } = authUser;
+    const user = await this.userService.updateUserActivate(
+      userId,
+      dto.isActivated
+    );
     return { user };
   }
 

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -166,6 +166,7 @@ export class UserService {
       numRecs: user.recommendations.length,
       email: user.email,
       role: user.role,
+      isActivated: user.isActivated,
       following: followingUsers,
     };
   }

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -88,6 +88,16 @@ export class UserService {
     return this.transformUser(user);
   }
 
+  public async updateUserActivate(
+    userId: string,
+    isActivated: boolean
+  ): Promise<User> {
+    const user: DbUser = await this.userRepository.updateUser(userId, {
+      isActivated,
+    });
+    return this.transformUser(user);
+  }
+
   public async validateHandle(handle: string): Promise<void> {
     const user = await this.userRepository.findUserByHandle(handle);
     if (user) {

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -118,9 +118,15 @@ export class UserService {
     userId: string,
     followingUserId: string
   ): Promise<void> {
-    // validate if the user exists
-    await this.userRepository.findUserById(userId);
-    await this.userRepository.findUserById(followingUserId);
+    // validate if the user exists and is activated
+    const followingUser =
+      await this.userRepository.findUserById(followingUserId);
+    if (!followingUser.isActivated) {
+      throw new RecnetError(
+        ErrorCode.ACCOUNT_NOT_ACTIVATED,
+        HttpStatus.BAD_REQUEST
+      );
+    }
 
     await this.followingRecordRepository.createFollowingRecord(
       userId,
@@ -132,9 +138,15 @@ export class UserService {
     userId: string,
     followingUserId: string
   ): Promise<void> {
-    // validate if the user exists
-    await this.userRepository.findUserById(userId);
-    await this.userRepository.findUserById(followingUserId);
+    // validate if the user exists and is activated
+    const followingUser =
+      await this.userRepository.findUserById(followingUserId);
+    if (!followingUser.isActivated) {
+      throw new RecnetError(
+        ErrorCode.ACCOUNT_NOT_ACTIVATED,
+        HttpStatus.BAD_REQUEST
+      );
+    }
 
     await this.followingRecordRepository.deleteFollowingRecord(
       userId,

--- a/apps/recnet-api/src/utils/auth/activated.guard.ts
+++ b/apps/recnet-api/src/utils/auth/activated.guard.ts
@@ -3,6 +3,7 @@ import {
   CanActivate,
   ExecutionContext,
   HttpStatus,
+  mixin,
 } from "@nestjs/common";
 
 import UserRepository from "@recnet-api/database/repository/user.repository";
@@ -12,31 +13,39 @@ import { recnetJwtPayloadSchema } from "@recnet/recnet-jwt";
 import { RecnetError } from "../error/recnet.error";
 import { ErrorCode } from "../error/recnet.error.const";
 
-@Injectable()
-export class ActivatedGuard implements CanActivate {
-  constructor(private readonly userRepository: UserRepository) {}
+export const ActivatedGuard = (allowNonActivated?: boolean) => {
+  @Injectable()
+  class ActivatedGuardMixin implements CanActivate {
+    constructor(private readonly userRepository: UserRepository) {}
 
-  async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
-    const recnetJwtPayload = recnetJwtPayloadSchema.safeParse(request.user);
-    if (!recnetJwtPayload.success) {
-      throw new RecnetError(
-        ErrorCode.ZOD_VALIDATION_ERROR,
-        HttpStatus.INTERNAL_SERVER_ERROR,
-        recnetJwtPayload.error.message
-      );
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      if (allowNonActivated) {
+        return true;
+      }
+
+      const request = context.switchToHttp().getRequest();
+      const recnetJwtPayload = recnetJwtPayloadSchema.safeParse(request.user);
+      if (!recnetJwtPayload.success) {
+        throw new RecnetError(
+          ErrorCode.ZOD_VALIDATION_ERROR,
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          recnetJwtPayload.error.message
+        );
+      }
+
+      const userId = recnetJwtPayload.data.recnet.userId;
+      const isActivated = await this.userRepository.isActivated(userId);
+
+      if (!isActivated) {
+        throw new RecnetError(
+          ErrorCode.ACCOUNT_NOT_ACTIVATED,
+          HttpStatus.UNAUTHORIZED
+        );
+      }
+
+      return true;
     }
-
-    const userId = recnetJwtPayload.data.recnet.userId;
-    const isActivated = await this.userRepository.isActivated(userId);
-
-    if (!isActivated) {
-      throw new RecnetError(
-        ErrorCode.ACCOUNT_NOT_ACTIVATED,
-        HttpStatus.UNAUTHORIZED
-      );
-    }
-
-    return true;
   }
-}
+  const guard = mixin(ActivatedGuardMixin);
+  return guard;
+};

--- a/apps/recnet-api/src/utils/auth/activated.guard.ts
+++ b/apps/recnet-api/src/utils/auth/activated.guard.ts
@@ -1,0 +1,42 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpStatus,
+} from "@nestjs/common";
+
+import UserRepository from "@recnet-api/database/repository/user.repository";
+
+import { recnetJwtPayloadSchema } from "@recnet/recnet-jwt";
+
+import { RecnetError } from "../error/recnet.error";
+import { ErrorCode } from "../error/recnet.error.const";
+
+@Injectable()
+export class ActivatedGuard implements CanActivate {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const recnetJwtPayload = recnetJwtPayloadSchema.safeParse(request.user);
+    if (!recnetJwtPayload.success) {
+      throw new RecnetError(
+        ErrorCode.ZOD_VALIDATION_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        recnetJwtPayload.error.message
+      );
+    }
+
+    const userId = recnetJwtPayload.data.recnet.userId;
+    const isActivated = await this.userRepository.isActivated(userId);
+
+    if (!isActivated) {
+      throw new RecnetError(
+        ErrorCode.ACCOUNT_NOT_ACTIVATED,
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+
+    return true;
+  }
+}

--- a/apps/recnet-api/src/utils/auth/auth.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.decorator.ts
@@ -4,15 +4,28 @@ import { verifyFirebaseJwt, verifyRecnetJwt } from "@recnet/recnet-jwt";
 
 import { UserRole } from "@recnet/recnet-api-model";
 
+import { ActivatedGuard } from "./activated.guard";
 import { AuthGuard } from "./auth.guard";
 import { RoleGuard } from "./role.guard";
 
-// RoleGuard must be placed after AuthGuard since it need to access the user info in the request
-export const Auth = (allowedRoles?: UserRole[]) => {
-  return applyDecorators(
-    UseGuards(new AuthGuard(verifyRecnetJwt)),
-    UseGuards(RoleGuard(allowedRoles))
-  );
+// ActivatedGuard and RoleGuard must be placed after AuthGuard since it need to access the user info in the request
+export const Auth = (
+  opts: {
+    allowedRoles?: UserRole[];
+    activatedOnly?: boolean;
+  } = {}
+) => {
+  const { activatedOnly = true, allowedRoles = ["USER", "ADMIN"] } = opts;
+
+  const guards = [UseGuards(new AuthGuard(verifyRecnetJwt))];
+
+  if (activatedOnly) {
+    guards.push(UseGuards(ActivatedGuard));
+  }
+
+  guards.push(UseGuards(RoleGuard(allowedRoles)));
+
+  return applyDecorators(...guards);
 };
 
 export const AuthFirebase = () => UseGuards(new AuthGuard(verifyFirebaseJwt));

--- a/apps/recnet-api/src/utils/auth/auth.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.decorator.ts
@@ -12,20 +12,16 @@ import { RoleGuard } from "./role.guard";
 export const Auth = (
   opts: {
     allowedRoles?: UserRole[];
-    activatedOnly?: boolean;
+    allowNonActivated?: boolean;
   } = {}
 ) => {
-  const { activatedOnly = true, allowedRoles = ["USER", "ADMIN"] } = opts;
+  const { allowNonActivated = false, allowedRoles = ["USER", "ADMIN"] } = opts;
 
-  const guards = [UseGuards(new AuthGuard(verifyRecnetJwt))];
-
-  if (activatedOnly) {
-    guards.push(UseGuards(ActivatedGuard));
-  }
-
-  guards.push(UseGuards(RoleGuard(allowedRoles)));
-
-  return applyDecorators(...guards);
+  return applyDecorators(
+    UseGuards(new AuthGuard(verifyRecnetJwt)),
+    UseGuards(ActivatedGuard(allowNonActivated)),
+    UseGuards(RoleGuard(allowedRoles))
+  );
 };
 
 export const AuthFirebase = () => UseGuards(new AuthGuard(verifyFirebaseJwt));

--- a/apps/recnet-api/src/utils/error/recnet.error.const.ts
+++ b/apps/recnet-api/src/utils/error/recnet.error.const.ts
@@ -7,6 +7,7 @@ export const ErrorCode = {
   INVALID_INVITE_CODE: 1005,
   HANDLE_EXISTS: 1006,
   START_DATE_AFTER_END_DATE: 1007,
+  ACCOUNT_NOT_ACTIVATED: 1008,
 
   // DB error codes
   DB_UNKNOWN_ERROR: 2000,
@@ -27,7 +28,9 @@ export const errorMessages = {
   [ErrorCode.INVALID_INVITE_CODE]: "Invalid invite code",
   [ErrorCode.HANDLE_EXISTS]: "Handle already exists",
   [ErrorCode.START_DATE_AFTER_END_DATE]: "Start date is after end date",
+  [ErrorCode.ACCOUNT_NOT_ACTIVATED]: "Your account is not activated",
   [ErrorCode.DB_UNKNOWN_ERROR]: "Database error",
   [ErrorCode.DB_USER_NOT_FOUND]: "User not found",
   [ErrorCode.DB_UNIQUE_CONSTRAINT]: "Unique constraint violation",
+  [ErrorCode.EMAIL_SEND_ERROR]: "Email send error",
 };

--- a/apps/recnet-api/src/utils/error/recnet.error.const.ts
+++ b/apps/recnet-api/src/utils/error/recnet.error.const.ts
@@ -28,7 +28,7 @@ export const errorMessages = {
   [ErrorCode.INVALID_INVITE_CODE]: "Invalid invite code",
   [ErrorCode.HANDLE_EXISTS]: "Handle already exists",
   [ErrorCode.START_DATE_AFTER_END_DATE]: "Start date is after end date",
-  [ErrorCode.ACCOUNT_NOT_ACTIVATED]: "Your account is not activated",
+  [ErrorCode.ACCOUNT_NOT_ACTIVATED]: "The user account is not activated",
   [ErrorCode.DB_UNKNOWN_ERROR]: "Database error",
   [ErrorCode.DB_USER_NOT_FOUND]: "User not found",
   [ErrorCode.DB_UNIQUE_CONSTRAINT]: "Unique constraint violation",

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -47,6 +47,18 @@ export const patchUserMeResponseSchema = z.object({
 });
 export type PatchUserMeResponse = z.infer<typeof patchUserMeResponseSchema>;
 
+// PATCH /users/me/activate
+export const patchUserMeActivateRequestSchema = z.object({
+  isActivated: z.boolean(),
+});
+export type PatchUserMeActivateRequest = z.infer<
+  typeof patchUserMeActivateRequestSchema
+>;
+
+export const patchUserMeActivateResponseSchema = z.object({
+  user: userSchema,
+});
+
 // POST /users/me
 export const postUserMeRequestSchema = userPreviewSchema
   .omit({

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -19,6 +19,7 @@ export const userPreviewSchema = z.object({
 export type UserPreview = z.infer<typeof userPreviewSchema>;
 
 export const userSchema = userPreviewSchema.extend({
+  isActivated: z.boolean(),
   email: z.string().email(),
   role: userRoleSchema,
   googleScholarLink: z.string().url().nullable(),


### PR DESCRIPTION
## Description

Tech design doc: [notion](https://www.notion.so/Deactivate-Account-6f43ae29772442e293d8f0d9641d2be1)

### Changes Summary

1. Add `isActivated` to the db user table
2. Exclude the following and followedBy users and user queries that are non-activated by Prisma where
3. Add ActivatedGuard in Auth decorator to prevent non-activated users access the APIs
4. Add PATCH /users/me/activate to reactivate/deactivate the account
5. Add validation in follow/unfollow/getRecs API to see if the target user is activated

## Related Issue

- https://github.com/lil-lab/recnet/issues/90

## Notes
How to test manually?

1. Hit `PATCH /users/me/activate` to deactivate your account.
2. Try accessing other APIs such as recs, invite-codes. You should get an error.
3. Try to use another account to follow and unfollow the deactivated user. You should get an error.
4. Try to access `GET /users`  API. The deactivated users should not appear in the response list by default.
5. Hit `PATCH /users/me/activate` to reactivate your account.
6. Try accessing other APIs and all records should remain the same.
<!-- Other thing to say -->

## TODO

- [ ] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
