### PR TITLE
[recnet-web] Rename recform components

### DIFF
--- a/apps/recnet/src/app/MobileNavigator.tsx
+++ b/apps/recnet/src/app/MobileNavigator.tsx
@@ -25,7 +25,7 @@ import { useAuth } from "./AuthContext";
 import { UserDropdown } from "./Headerbar";
 import { InviteCodePopover } from "./feeds/InviteCodePopover";
 
-import { RecForm } from "../components/rec/RecForm";
+import { RecEditForm } from "../components/rec/RecEditForm";
 
 function RecFormContent(props: { setOpen: (open: boolean) => void }) {
   const { setOpen } = props;
@@ -96,7 +96,7 @@ function RecFormContent(props: { setOpen: (open: boolean) => void }) {
       </Text>
       <Flex className="w-full">
         {rec ? (
-          <RecForm
+          <RecEditForm
             currentRec={rec}
             onFinish={() => {
               setOpen(false);

--- a/apps/recnet/src/app/MobileNavigator.tsx
+++ b/apps/recnet/src/app/MobileNavigator.tsx
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 
 import { trpc } from "@recnet/recnet-web/app/_trpc/client";
 import { SkeletonText, Skeleton } from "@recnet/recnet-web/components/Skeleton";
-import { RecArticleForm } from "@recnet/recnet-web/components/rec/RecArticleForm";
+import { NewArticleForm } from "@recnet/recnet-web/components/rec/NewArticleForm";
 import { UserRole } from "@recnet/recnet-web/constant";
 import { useGoogleLogin } from "@recnet/recnet-web/firebase/auth";
 import { cn } from "@recnet/recnet-web/utils/cn";
@@ -103,7 +103,7 @@ function RecFormContent(props: { setOpen: (open: boolean) => void }) {
             }}
           />
         ) : (
-          <RecArticleForm
+          <NewArticleForm
             currentRec={rec}
             onFinish={() => {
               setOpen(false);

--- a/apps/recnet/src/app/feeds/LeftPanel.tsx
+++ b/apps/recnet/src/app/feeds/LeftPanel.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { Skeleton, SkeletonText } from "@recnet/recnet-web/components/Skeleton";
 import { RecArticleForm } from "@recnet/recnet-web/components/rec/RecArticleForm";
-import { RecForm } from "@recnet/recnet-web/components/rec/RecForm";
+import { RecEditForm } from "@recnet/recnet-web/components/rec/RecEditForm";
 import { cn } from "@recnet/recnet-web/utils/cn";
 
 import {
@@ -175,7 +175,7 @@ export function LeftPanel() {
                 Back
               </div>
               {rec ? (
-                <RecForm
+                <RecEditForm
                   currentRec={rec}
                   onFinish={() => {
                     setIsRecFormOpen(false);

--- a/apps/recnet/src/app/feeds/LeftPanel.tsx
+++ b/apps/recnet/src/app/feeds/LeftPanel.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 
 import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { Skeleton, SkeletonText } from "@recnet/recnet-web/components/Skeleton";
-import { RecArticleForm } from "@recnet/recnet-web/components/rec/RecArticleForm";
+import { NewArticleForm } from "@recnet/recnet-web/components/rec/NewArticleForm";
 import { RecEditForm } from "@recnet/recnet-web/components/rec/RecEditForm";
 import { cn } from "@recnet/recnet-web/utils/cn";
 
@@ -182,7 +182,7 @@ export function LeftPanel() {
                   }}
                 />
               ) : (
-                <RecArticleForm
+                <NewArticleForm
                   currentRec={rec}
                   onFinish={() => {
                     setIsRecFormOpen(false);

--- a/apps/recnet/src/components/rec/NewArticleForm.tsx
+++ b/apps/recnet/src/components/rec/NewArticleForm.tsx
@@ -139,7 +139,16 @@ const RecArticleFormSchema = z.object({
   month: z.number().optional(),
 });
 
-export function RecArticleForm(props: {
+/**
+ * Two-step form to recommend a new article.
+ * Two use cases:
+ * 1. User doesn't have an upcoming rec in this cycle
+ * 2. User has an upcoming rec in this cycle, but want to recommend another article
+ *
+ * @param {Function} props.onFinish - Callback function to be called when the form is finished.
+ * @param {Rec | null} props.currentRec - The current recommendation, if any. This is used to differentiate between the two use cases and which API endpoint to call.
+ */
+export function NewArticleForm(props: {
   onFinish?: () => void;
   currentRec: Rec | null;
 }) {

--- a/apps/recnet/src/components/rec/RecEditForm.tsx
+++ b/apps/recnet/src/components/rec/RecEditForm.tsx
@@ -16,7 +16,7 @@ import { trpc } from "@recnet/recnet-web/app/_trpc/client";
 import { ReportEmailAccount } from "@recnet/recnet-web/app/not-found";
 import { Accordion } from "@recnet/recnet-web/components/Accordion";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
-import { RecArticleForm } from "@recnet/recnet-web/components/rec/RecArticleForm";
+import { NewArticleForm } from "@recnet/recnet-web/components/rec/NewArticleForm";
 import { cn } from "@recnet/recnet-web/utils/cn";
 
 import {
@@ -68,7 +68,7 @@ export function RecEditForm(props: { onFinish?: () => void; currentRec: Rec }) {
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
-          <RecArticleForm currentRec={currentRec} onFinish={onFinish} />
+          <NewArticleForm currentRec={currentRec} onFinish={onFinish} />
         </motion.div>
       ) : (
         <motion.div

--- a/apps/recnet/src/components/rec/RecEditForm.tsx
+++ b/apps/recnet/src/components/rec/RecEditForm.tsx
@@ -34,7 +34,14 @@ const RecFormSchema = z.object({
     .min(1, "Description cannot be blank"),
 });
 
-export function RecForm(props: { onFinish?: () => void; currentRec: Rec }) {
+/**
+ * Used to edit the description of an upcoming rec.
+ *
+ * Only showed when user has submitted an upcoming rec.
+ *
+ * Redirected to `NewArticleForm` if user wants to change the article.
+ */
+export function RecEditForm(props: { onFinish?: () => void; currentRec: Rec }) {
   const { onFinish = () => {}, currentRec } = props;
   const [recNewArticle, setRecNewArticle] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Rename two confusing components and give a better semantic name to avoid confusion in the future.

### 1. `RecArticleForm` -> `NewArticleForm`
A two-step flow to recommend a new article. Two use cases:
1. User doesn't have an upcoming rec in this cycle yet.
2. User already made a rec, but want to rec another article

### 2. `RecForm` -> `RecEditForm`
A simple form for user who already made a rec in this cycle to edit the description (tl;dr field).
There's a button like `Rec another form?` and it will redirect user to `NewArticleForm` 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Notes

<!-- Other thing to say -->
Manual test: 

- Everything should behave the same.

## TODO

- [x] Paste the testing link: https://recnet-kpjh4tc65-recnet-542617e7.vercel.app/feeds
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
