### PR TITLE
[recnet-api] Self-rec flag 

### DIFF
--- a/apps/recnet-api/prisma/migrations/20240907214307_add_self_rec_flag_into_rec_model/down.sql
+++ b/apps/recnet-api/prisma/migrations/20240907214307_add_self_rec_flag_into_rec_model/down.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Recommendation" DROP COLUMN "isSelfRec";
+

--- a/apps/recnet-api/prisma/migrations/20240907214307_add_self_rec_flag_into_rec_model/migration.sql
+++ b/apps/recnet-api/prisma/migrations/20240907214307_add_self_rec_flag_into_rec_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Recommendation" ADD COLUMN     "isSelfRec" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/recnet-api/prisma/schema.prisma
+++ b/apps/recnet-api/prisma/schema.prisma
@@ -5,13 +5,13 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["fullTextSearch"]
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("PRISMA_DATABASE_URL")
+  provider = "postgresql"
+  url      = env("PRISMA_DATABASE_URL")
 }
 
 // Define enum types
@@ -33,107 +33,109 @@ enum CronStatus {
 }
 
 model User {
-  id                  String     @id @db.VarChar(64) @default(uuid()) // Primary key, UUID type
-  provider            Provider   // Enum type
-  providerId          String     @db.VarChar(128)
-  @@unique([provider, providerId])
-  email               String     @db.VarChar(128) @unique
-  handle              String     @db.VarChar(32) @unique
-  displayName         String     @db.VarChar(32)
-  inviteCode          String?    @db.VarChar(64)
-  photoUrl            String     @db.VarChar(256)
-  affiliation         String?    @db.VarChar(64)
-  bio                 String?    @db.VarChar(200)
-  url                 String?    @db.VarChar(512)
-  googleScholarLink   String?    @db.VarChar(512)
-  semanticScholarLink String?    @db.VarChar(512)
-  openReviewUserName  String?    @db.VarChar(64)
+  id                  String   @id @default(uuid()) @db.VarChar(64) // Primary key, UUID type
+  provider            Provider // Enum type
+  providerId          String   @db.VarChar(128)
+  email               String   @unique @db.VarChar(128)
+  handle              String   @unique @db.VarChar(32)
+  displayName         String   @db.VarChar(32)
+  inviteCode          String?  @db.VarChar(64)
+  photoUrl            String   @db.VarChar(256)
+  affiliation         String?  @db.VarChar(64)
+  bio                 String?  @db.VarChar(200)
+  url                 String?  @db.VarChar(512)
+  googleScholarLink   String?  @db.VarChar(512)
+  semanticScholarLink String?  @db.VarChar(512)
+  openReviewUserName  String?  @db.VarChar(64)
   lastLoginAt         DateTime
   role                Role       @default(USER) // Enum type
   isActivated         Boolean    @default(true)
   createdAt           DateTime   @default(now())
   updatedAt           DateTime   @default(now()) @updatedAt
 
-  followedBy          FollowingRecord[] @relation("FollowedBy")
-  following           FollowingRecord[] @relation("Following")
-  recommendations     Recommendation[]
-  inviteCodeOwner     InviteCode[]  @relation("InviteCodeOwner")
-  inviteCodeUsed      InviteCode?   @relation("InviteCodeUsedBy")
-  announcements       Announcement[]
+  followedBy      FollowingRecord[] @relation("FollowedBy")
+  following       FollowingRecord[] @relation("Following")
+  recommendations Recommendation[]
+  inviteCodeOwner InviteCode[]      @relation("InviteCodeOwner")
+  inviteCodeUsed  InviteCode?       @relation("InviteCodeUsedBy")
+  announcements   Announcement[]
+
+  @@unique([provider, providerId])
 }
 
 model FollowingRecord {
-  followingId     String    @db.VarChar(64)
-  followedById    String    @db.VarChar(64)
-  createdAt       DateTime  @default(now())
+  followingId  String   @db.VarChar(64)
+  followedById String   @db.VarChar(64)
+  createdAt    DateTime @default(now())
+  following    User     @relation("FollowedBy", fields: [followingId], references: [id])
+  followedBy   User     @relation("Following", fields: [followedById], references: [id])
 
   @@id([followingId, followedById])
-  following       User @relation("FollowedBy", fields: [followingId], references: [id])
-  followedBy      User @relation("Following", fields: [followedById], references: [id])
 }
 
 model Recommendation {
-  id          String    @id @db.VarChar(64) @default(uuid())
-  userId      String    @db.VarChar(64)
-  articleId   String    @db.VarChar(64)
+  id          String   @id @default(uuid()) @db.VarChar(64)
+  userId      String   @db.VarChar(64)
+  articleId   String   @db.VarChar(64)
   description String
+  isSelfRec   Boolean  @default(false)
   cutoff      DateTime
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @default(now()) @updatedAt
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
 
-  user        User      @relation(fields: [userId], references: [id]) // User who made the recommendation
-  article     Article   @relation(fields: [articleId], references: [id]) // Article being recommended
+  user    User    @relation(fields: [userId], references: [id]) // User who made the recommendation
+  article Article @relation(fields: [articleId], references: [id]) // Article being recommended
 }
 
 model Article {
-  id          String    @id @db.VarChar(64) @default(uuid())
-  doi         String?   @db.VarChar(32)
-  title       String    @db.VarChar(256)
-  author      String
-  link        String    @db.VarChar(256)
-  year        Int       @db.SmallInt
-  month       Int?      @db.SmallInt
-  isVerified  Boolean   @default(false)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @default(now()) @updatedAt
+  id         String   @id @default(uuid()) @db.VarChar(64)
+  doi        String?  @db.VarChar(32)
+  title      String   @db.VarChar(256)
+  author     String
+  link       String   @db.VarChar(256)
+  year       Int      @db.SmallInt
+  month      Int?     @db.SmallInt
+  isVerified Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @default(now()) @updatedAt
 
   recommendations Recommendation[]
 }
 
 model InviteCode {
-  id          Int       @id @default(autoincrement())
-  code        String    @db.VarChar(64) @unique
-  ownerId     String    @db.VarChar(64)
-  issuedAt    DateTime  @default(now())
-  usedById    String?   @db.VarChar(64) @unique
-  usedAt      DateTime?
+  id       Int       @id @default(autoincrement())
+  code     String    @unique @db.VarChar(64)
+  ownerId  String    @db.VarChar(64)
+  issuedAt DateTime  @default(now())
+  usedById String?   @unique @db.VarChar(64)
+  usedAt   DateTime?
 
-  owner       User      @relation("InviteCodeOwner", fields: [ownerId], references: [id])
-  usedBy      User?     @relation("InviteCodeUsedBy", fields: [usedById], references: [id])
+  owner  User  @relation("InviteCodeOwner", fields: [ownerId], references: [id])
+  usedBy User? @relation("InviteCodeUsedBy", fields: [usedById], references: [id])
 }
 
 model Announcement {
-  id          Int       @id @default(autoincrement())
-  title       String    @db.VarChar(128)
+  id          Int      @id @default(autoincrement())
+  title       String   @db.VarChar(128)
   content     String
   startAt     DateTime
   endAt       DateTime
-  isActivated Boolean   @default(true)
-  allowClose  Boolean   @default(false)
-  createdById  String    @db.VarChar(64)
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @default(now()) @updatedAt
+  isActivated Boolean  @default(true)
+  allowClose  Boolean  @default(false)
+  createdById String   @db.VarChar(64)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
 
-  createdBy   User      @relation(fields: [createdById], references: [id])
+  createdBy User @relation(fields: [createdById], references: [id])
 }
 
 model WeeklyDigestCronLog {
-  id          Int       @id @default(autoincrement())
-  cutoff      DateTime
-  startTime   DateTime  @default(now())
-  endTime     DateTime?
-  status      CronStatus
-  result      Json?
-  errorMsg    String?
-  createdAt   DateTime  @default(now())
+  id        Int        @id @default(autoincrement())
+  cutoff    DateTime
+  startTime DateTime   @default(now())
+  endTime   DateTime?
+  status    CronStatus
+  result    Json?
+  errorMsg  String?
+  createdAt DateTime   @default(now())
 }

--- a/apps/recnet-api/src/database/repository/rec.repository.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.ts
@@ -52,10 +52,12 @@ export default class RecRepository {
   public async createRec(
     userId: string,
     description: string,
+    isSelfRec: boolean,
     articleId: string
   ): Promise<Rec> {
     return this.prisma.recommendation.create({
       data: {
+        isSelfRec: isSelfRec,
         description: description,
         cutoff: getNextCutOff(),
         user: {
@@ -76,10 +78,12 @@ export default class RecRepository {
   public async updateRec(
     id: string,
     description: string,
+    isSelfRec: boolean,
     articleId?: string
   ): Promise<Rec> {
     const data: Prisma.RecommendationUpdateInput = {
       description: description,
+      isSelfRec: isSelfRec,
     };
     if (articleId) {
       data.article = {

--- a/apps/recnet-api/src/modules/rec/dto/create.rec.dto.ts
+++ b/apps/recnet-api/src/modules/rec/dto/create.rec.dto.ts
@@ -14,6 +14,11 @@ export class CreateRecDto {
   description: string;
 
   @ApiProperty({
+    description: "Whether the recommendation is self-recommendation or not",
+  })
+  isSelfRec: boolean;
+
+  @ApiProperty({
     description: "Article id",
     nullable: true,
   })

--- a/apps/recnet-api/src/modules/rec/dto/update.rec.dto.ts
+++ b/apps/recnet-api/src/modules/rec/dto/update.rec.dto.ts
@@ -14,6 +14,11 @@ export class UpdateRecDto {
   description: string;
 
   @ApiProperty({
+    description: "Whether the recommendation is self-recommendation or not",
+  })
+  isSelfRec: boolean;
+
+  @ApiProperty({
     description: "Article id",
     nullable: true,
   })

--- a/apps/recnet-api/src/modules/rec/rec.controller.ts
+++ b/apps/recnet-api/src/modules/rec/rec.controller.ts
@@ -121,6 +121,7 @@ export class RecController {
       body.articleId,
       body.article,
       body.description,
+      body.isSelfRec,
       userId
     );
   }
@@ -143,6 +144,7 @@ export class RecController {
       body.articleId,
       body.article,
       body.description,
+      body.isSelfRec,
       userId
     );
   }

--- a/apps/recnet-api/src/modules/rec/rec.service.ts
+++ b/apps/recnet-api/src/modules/rec/rec.service.ts
@@ -106,6 +106,7 @@ export class RecService {
     articleId: string | null,
     article: CreateArticleInput | null,
     description: string,
+    isSelfRec: boolean,
     userId: string
   ): Promise<CreateRecResponse> {
     const dbRec = await this.recRepository.findUpcomingRec(userId);
@@ -134,6 +135,7 @@ export class RecService {
     const newRec = await this.recRepository.createRec(
       userId,
       description,
+      isSelfRec,
       articleIdToConnect
     );
     return {
@@ -145,6 +147,7 @@ export class RecService {
     articleId: string | null,
     article: CreateArticleInput | null,
     description: string,
+    isSelfRec: boolean,
     userId: string
   ): Promise<UpdateRecResponse> {
     const dbRec = await this.recRepository.findUpcomingRec(userId);
@@ -172,11 +175,16 @@ export class RecService {
     }
     let updatedRec: DbRec;
     if (articleIdToConnect === dbRec.article.id) {
-      updatedRec = await this.recRepository.updateRec(dbRec.id, description);
+      updatedRec = await this.recRepository.updateRec(
+        dbRec.id,
+        description,
+        isSelfRec
+      );
     } else {
       updatedRec = await this.recRepository.updateRec(
         dbRec.id,
         description,
+        isSelfRec,
         articleIdToConnect
       );
     }

--- a/apps/recnet/src/components/rec/RecArticleForm.tsx
+++ b/apps/recnet/src/components/rec/RecArticleForm.tsx
@@ -228,6 +228,7 @@ export function RecArticleForm(props: {
                   articleId: res.data.articleId,
                   article: null,
                   description: res.data.description,
+                  isSelfRec: false, // TODO: add self rec feature
                 }
               : {
                   articleId: null,
@@ -240,6 +241,7 @@ export function RecArticleForm(props: {
                     month: res.data.month ?? null,
                   },
                   description: res.data.description,
+                  isSelfRec: false, // TODO: add self rec feature
                 };
             if (currentRec) {
               await editRecMutation.mutateAsync(formSubmissionData);

--- a/apps/recnet/src/components/rec/RecForm.tsx
+++ b/apps/recnet/src/components/rec/RecForm.tsx
@@ -114,6 +114,7 @@ export function RecForm(props: { onFinish?: () => void; currentRec: Rec }) {
                   articleId: currentRec.article.id,
                   article: null,
                   description: res.data.description,
+                  isSelfRec: false, // TODO: implement self rec
                 });
                 toast.success("Rec updated successfully.");
                 await utils.getUpcomingRec.invalidate();

--- a/apps/recnet/src/server/routers/rec.ts
+++ b/apps/recnet/src/server/routers/rec.ts
@@ -69,22 +69,24 @@ export const recRouter = router({
     .input(postRecsUpcomingRequestSchema)
     .mutation(async (opts) => {
       const { recnetApi } = opts.ctx;
-      const { articleId, article, description } = opts.input;
+      const { articleId, article, description, isSelfRec } = opts.input;
       await recnetApi.post("/recs/upcoming", {
         articleId,
         article,
         description,
+        isSelfRec,
       });
     }),
   editUpcomingRec: checkRecnetJWTProcedure
     .input(patchRecsUpcomingRequestSchema)
     .mutation(async (opts) => {
       const { recnetApi } = opts.ctx;
-      const { articleId, article, description } = opts.input;
+      const { articleId, article, description, isSelfRec } = opts.input;
       await recnetApi.patch(`/recs/upcoming`, {
         articleId,
         article,
         description,
+        isSelfRec,
       });
     }),
   deleteUpcomingRec: checkRecnetJWTProcedure.mutation(async (opts) => {

--- a/libs/recnet-api-model/src/lib/api/rec.ts
+++ b/libs/recnet-api-model/src/lib/api/rec.ts
@@ -15,6 +15,7 @@ export const recFormSubmissionSchema = z.intersection(
   ]),
   z.object({
     description: z.string(),
+    isSelfRec: z.boolean(),
   })
 );
 export type RecFormSubmission = z.infer<typeof recFormSubmissionSchema>;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We need a “self-rec” flag to display at feeds and email digest. 

This PR updated prisma schema and update APIs to enable marking rec as "self-rec".

Design docs: https://www.notion.so/Self-review-feature-4fcb73e72d0d41abbb4dafef0c672512?pvs=4

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #269 

## Notes

<!-- Other thing to say -->

## Test

- Open recnet web app and try to create rec/edit rec.
- All bahaviors should remain the same.
- Try to use Postman to turn a rec to “self-rec” rec
- Verify the API is working properly via inspecting db (open prisma studio)
- Try to use Postman to create a “self-rec” rec
- Verify the API is working properly via inspecting db (open prisma studio)

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
