### PR TITLE
[recnet-api] Disable nx cloud

### DIFF
--- a/apps/recnet-api/buildspec.yml
+++ b/apps/recnet-api/buildspec.yml
@@ -9,6 +9,7 @@ phases:
       - pnpm i --frozen-lockfile
   pre_build:
     commands:
+      - export NX_NO_CLOUD=true
       - pnpm nx clean recnet-api
       - pnpm nx prisma:generate recnet-api
   build:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Nx will fail the whole pipeline if nx cloud is not activated. We need to disable this feature.
Learn more: https://github.com/nrwl/nx/issues/22444

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
Solutions: https://github.com/nrwl/nx/issues/22444#issuecomment-2016671263

## TODO

- [ ] Paste the testing link
- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
