### PR TITLE
[recnet-api] Add self rec in rec

### DIFF
--- a/apps/recnet-api/src/database/repository/rec.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.type.ts
@@ -7,6 +7,7 @@ export const rec = Prisma.validator<Prisma.RecommendationDefaultArgs>()({
   select: {
     id: true,
     description: true,
+    isSelfRec: true,
     cutoff: true,
     user: {
       select: userPreview.select,

--- a/apps/recnet-api/src/modules/rec/entities/rec.entity.ts
+++ b/apps/recnet-api/src/modules/rec/entities/rec.entity.ts
@@ -12,6 +12,9 @@ export class Rec {
   description: string;
 
   @ApiProperty()
+  isSelfRec: boolean;
+
+  @ApiProperty()
   cutoff: string;
 
   @ApiProperty()

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -44,6 +44,7 @@ export type Article = z.infer<typeof articleSchema>;
 export const recSchema = z.object({
   id: z.string(),
   description: z.string(),
+  isSelfRec: z.boolean(),
   cutoff: dateSchema,
   user: userPreviewSchema,
   article: articleSchema,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add `isSelfRec` property to rec api model.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #269 

## Notes

<!-- Other thing to say -->

## Test

Try to hit `POST /recs/upcoming`, `PATCH /recs/upcoming`, or `GET /recs/upcoming` in postman, the response data should contain `isSelfRec` field.

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
