### PR TITLE
[recnet-web][v1.11.0] Self rec checkbox in rec forms

### DIFF
--- a/apps/recnet/CHANGELOG.md
+++ b/apps/recnet/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.11.0](https://github.com/lil-lab/recnet/compare/recnet-web-v1.10.2...recnet-web-v1.11.0) (2024-09-10)
+
+
+### Features
+
+* add ActivatedGuard ([f5ddd31](https://github.com/lil-lab/recnet/commit/f5ddd31df11cff3f99f1d0dc1f39648bc0ff4c52))
+* add isActivated in user response ([21d3a07](https://github.com/lil-lab/recnet/commit/21d3a0747820884861fd12f4fbd61f89ed6e236e))
+* add isActivated to db user table ([2e33ac9](https://github.com/lil-lab/recnet/commit/2e33ac9b940a1edebf632d597dd1f4614f7d604c))
+* add isSelfRec option in RecEditForm ([a22b861](https://github.com/lil-lab/recnet/commit/a22b861f37e1dbf4cba0f6434735cfc75c07f750))
+* add new field to rec table: isSelfRec ([1a08aea](https://github.com/lil-lab/recnet/commit/1a08aeaa9d87a2fb31a59f4276c0f7541425fed7))
+* add self rec badge in email ([dfbf0e9](https://github.com/lil-lab/recnet/commit/dfbf0e9c2e3beb56e99b682b049f56d560811c37))
+* add self-rec checkbox in NewArticleForm ([a096434](https://github.com/lil-lab/recnet/commit/a096434043c8ecef10337bf4af9dd82e9ca33afc))
+* add validation to follow/unfollow and get recs api ([d685ee1](https://github.com/lil-lab/recnet/commit/d685ee12f801e405cc0fc0106254027932fa5306))
+* create PATCH /update/me/activate API ([d9682af](https://github.com/lil-lab/recnet/commit/d9682af3748879d4091cf0101b28bb2e077fb9b6))
+* exclude non-activated following records ([68e46c0](https://github.com/lil-lab/recnet/commit/68e46c02560cc1bf69feced833f9ae95563ad582))
+* exclude non-activated users when querying users ([a1b8f57](https://github.com/lil-lab/recnet/commit/a1b8f57531f216d71e7d7d0effd39c0d3885f8f5))
+* include selfRec property in rec model ([16d3f55](https://github.com/lil-lab/recnet/commit/16d3f554c424c7e9ae998369db80f2221e9138df))
+* mark self rec in rec card ([25dcc3d](https://github.com/lil-lab/recnet/commit/25dcc3df1310330dbd148112569a542776f1b804))
+* update create/edit upcoming rec APIs to enable self-rec feature ([15d1915](https://github.com/lil-lab/recnet/commit/15d1915996fdf8f5be6fe660097b51fdcfa8f64d))
+
+
+### Bug Fixes
+
+* add error ui when api is down ([cf199d6](https://github.com/lil-lab/recnet/commit/cf199d6d1dd1ad15086851d81e4cfda257304082))
+* disable nx cloud in CI pipeline ([74fd55c](https://github.com/lil-lab/recnet/commit/74fd55caad5b0b81d45a903294a18f18a81abc77))
 ## [1.10.2](https://github.com/lil-lab/recnet/compare/recnet-web-v1.10.0...recnet-web-v1.10.2) (2024-09-08)
 
 ### Bug Fixes

--- a/apps/recnet/package.json
+++ b/apps/recnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recnet",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "commit-and-tag-version": {
     "skip": {
       "commit": true

--- a/apps/recnet/src/components/RecCard.tsx
+++ b/apps/recnet/src/components/RecCard.tsx
@@ -116,32 +116,30 @@ export function RecCard(props: { recs: Rec[]; showDate?: boolean }) {
           <Flex className="items-start gap-x-3 px-4 py-2" key={user.id}>
             <Avatar user={user} className="w-[40px] aspect-square" />
             <Flex className="flex flex-col gap-y-1">
-              <Flex className="gap-x-2">
-                <Text className="items-end">
-                  <RecNetLink
-                    href={`/${user.handle}`}
-                    radixLinkProps={{
-                      size: "2",
-                    }}
-                  >
-                    <Text size="2">{user.displayName}</Text>
-                  </RecNetLink>
-                  {showDate ? (
-                    <Text
-                      size="2"
-                      className="text-gray-10"
-                      weight="medium"
-                    >{` recommended on on ${cutoff}`}</Text>
-                  ) : null}
-                  {rec.isSelfRec ? (
-                    <Tooltip content="This recommendation was made by the same person who wrote the article.">
-                      <Badge color="orange" className="ml-2 cursor-pointer">
-                        Self Rec
-                      </Badge>
-                    </Tooltip>
-                  ) : null}
-                </Text>
-              </Flex>
+              <Text className="items-end">
+                <RecNetLink
+                  href={`/${user.handle}`}
+                  radixLinkProps={{
+                    size: "2",
+                  }}
+                >
+                  <Text size="2">{user.displayName}</Text>
+                </RecNetLink>
+                {showDate ? (
+                  <Text
+                    size="2"
+                    className="text-gray-10"
+                    weight="medium"
+                  >{` recommended on on ${cutoff}`}</Text>
+                ) : null}
+                {rec.isSelfRec ? (
+                  <Tooltip content="This recommendation was made by the same person who wrote the article.">
+                    <Badge color="orange" className="ml-2 cursor-pointer">
+                      Self Rec
+                    </Badge>
+                  </Tooltip>
+                ) : null}
+              </Text>
               <Flex>
                 <Text size="3" className="text-gray-11">
                   {rec.description}

--- a/apps/recnet/src/components/RecCard.tsx
+++ b/apps/recnet/src/components/RecCard.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon } from "@radix-ui/react-icons";
-import { Flex, Text } from "@radix-ui/themes";
+import { Badge, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { ChevronRight } from "lucide-react";
 
 import { Avatar } from "@recnet/recnet-web/components/Avatar";
@@ -116,23 +116,32 @@ export function RecCard(props: { recs: Rec[]; showDate?: boolean }) {
           <Flex className="items-start gap-x-3 px-4 py-2" key={user.id}>
             <Avatar user={user} className="w-[40px] aspect-square" />
             <Flex className="flex flex-col gap-y-1">
-              <Text className="items-end">
-                <RecNetLink
-                  href={`/${user.handle}`}
-                  radixLinkProps={{
-                    size: "2",
-                  }}
-                >
-                  <Text size="2">{user.displayName}</Text>
-                </RecNetLink>
-                {showDate ? (
-                  <Text
-                    size="2"
-                    className="text-gray-10"
-                    weight="medium"
-                  >{` recommended on on ${cutoff}`}</Text>
-                ) : null}
-              </Text>
+              <Flex className="gap-x-2">
+                <Text className="items-end">
+                  <RecNetLink
+                    href={`/${user.handle}`}
+                    radixLinkProps={{
+                      size: "2",
+                    }}
+                  >
+                    <Text size="2">{user.displayName}</Text>
+                  </RecNetLink>
+                  {showDate ? (
+                    <Text
+                      size="2"
+                      className="text-gray-10"
+                      weight="medium"
+                    >{` recommended on on ${cutoff}`}</Text>
+                  ) : null}
+                  {rec.isSelfRec ? (
+                    <Tooltip content="This recommendation was made by the same person who wrote the article.">
+                      <Badge color="orange" className="ml-2 cursor-pointer">
+                        Self Rec
+                      </Badge>
+                    </Tooltip>
+                  ) : null}
+                </Text>
+              </Flex>
               <Flex>
                 <Text size="3" className="text-gray-11">
                   {rec.description}

--- a/apps/recnet/src/components/rec/NewArticleForm.tsx
+++ b/apps/recnet/src/components/rec/NewArticleForm.tsx
@@ -6,14 +6,21 @@ import {
   Link2Icon,
   PersonIcon,
   SewingPinIcon,
-} from "@radix-ui/react-icons";
-import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  QuestionMarkCircledIcon,
 } from "@radix-ui/react-icons";
 import * as Select from "@radix-ui/react-select";
-import { Text, Flex, Button, TextField, TextArea } from "@radix-ui/themes";
+import {
+  Text,
+  Flex,
+  Button,
+  TextField,
+  TextArea,
+  Checkbox,
+  Tooltip,
+} from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
 import { forwardRef, useState } from "react";
 import { useForm, Controller, useFormState } from "react-hook-form";
@@ -128,6 +135,7 @@ const RecArticleFormSchema = z.object({
     .string()
     .max(280, "Description should be less than 280 chars")
     .min(1, "Description cannot be blank"),
+  isSelfRec: z.boolean().default(false),
   year: z.coerce
     .number()
     .refine((val) => {
@@ -237,7 +245,7 @@ export function NewArticleForm(props: {
                   articleId: res.data.articleId,
                   article: null,
                   description: res.data.description,
-                  isSelfRec: false, // TODO: add self rec feature
+                  isSelfRec: res.data.isSelfRec,
                 }
               : {
                   articleId: null,
@@ -250,7 +258,7 @@ export function NewArticleForm(props: {
                     month: res.data.month ?? null,
                   },
                   description: res.data.description,
-                  isSelfRec: false, // TODO: add self rec feature
+                  isSelfRec: res.data.isSelfRec,
                 };
             if (currentRec) {
               await editRecMutation.mutateAsync(formSubmissionData);
@@ -487,6 +495,33 @@ export function NewArticleForm(props: {
                     {`${watch("description")?.length ?? 0}/280`}
                   </Text>
                 </div>
+              </div>
+              <div>
+                <Controller
+                  control={control}
+                  name="isSelfRec"
+                  defaultValue={false}
+                  render={({ field }) => (
+                    <Flex gap="2">
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={(isChecked) => {
+                          field.onChange(isChecked);
+                        }}
+                      />
+                      <Text size="1" className="text-gray-11">
+                        Self recommendation
+                      </Text>
+                      <Tooltip content="Please mark recommendation of papers that you are an author of. Self recommendation are completely OK, but we want to mark them in the feeds.">
+                        <QuestionMarkCircledIcon
+                          width="18"
+                          height="18"
+                          className="text-gray-11 cursor-pointer"
+                        />
+                      </Tooltip>
+                    </Flex>
+                  )}
+                />
               </div>
               <Text size="1" weight="medium" className="text-gray-9 p-1">
                 {`You can edit at anytime before this week's cutoff: ${getVerboseDateString(getNextCutOff())}.`}

--- a/apps/recnet/src/components/rec/RecEditForm.tsx
+++ b/apps/recnet/src/components/rec/RecEditForm.tsx
@@ -4,11 +4,20 @@ import {
   Link2Icon,
   PersonIcon,
   SewingPinIcon,
+  QuestionMarkCircledIcon,
 } from "@radix-ui/react-icons";
-import { Text, Flex, Button, TextField, TextArea } from "@radix-ui/themes";
+import {
+  Text,
+  Flex,
+  Button,
+  TextField,
+  TextArea,
+  Tooltip,
+  Checkbox,
+} from "@radix-ui/themes";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
-import { useForm, useFormState } from "react-hook-form";
+import { Controller, useForm, useFormState } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -32,6 +41,7 @@ const RecFormSchema = z.object({
     .string()
     .max(280, "Description should be less than 280 chars")
     .min(1, "Description cannot be blank"),
+  isSelfRec: z.boolean(),
 });
 
 /**
@@ -50,6 +60,7 @@ export function RecEditForm(props: { onFinish?: () => void; currentRec: Rec }) {
     resolver: zodResolver(RecFormSchema),
     defaultValues: {
       description: currentRec.description,
+      isSelfRec: currentRec.isSelfRec,
     },
     mode: "onTouched",
   });
@@ -121,7 +132,7 @@ export function RecEditForm(props: { onFinish?: () => void; currentRec: Rec }) {
                   articleId: currentRec.article.id,
                   article: null,
                   description: res.data.description,
-                  isSelfRec: false, // TODO: implement self rec
+                  isSelfRec: res.data.isSelfRec,
                 });
                 toast.success("Rec updated successfully.");
                 await utils.getUpcomingRec.invalidate();
@@ -217,6 +228,32 @@ export function RecEditForm(props: { onFinish?: () => void; currentRec: Rec }) {
                   {`${watch("description")?.length ?? 0}/280`}
                 </Text>
               </div>
+            </div>
+            <div>
+              <Controller
+                control={control}
+                name="isSelfRec"
+                render={({ field }) => (
+                  <Flex gap="2">
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={(isChecked) => {
+                        field.onChange(isChecked);
+                      }}
+                    />
+                    <Text size="1" className="text-gray-11">
+                      Self recommendation
+                    </Text>
+                    <Tooltip content="Please mark recommendation of papers that you are an author of. Self recommendation are completely OK, but we want to mark them in the feeds.">
+                      <QuestionMarkCircledIcon
+                        width="18"
+                        height="18"
+                        className="text-gray-11 cursor-pointer"
+                      />
+                    </Tooltip>
+                  </Flex>
+                )}
+              />
             </div>
             <Text size="1" weight="medium" className="text-gray-9 p-1">
               {`You can edit at anytime before this week's cutoff: ${getVerboseDateString(getNextCutOff())}.`}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Add "self-rec" checkbox in rec forms (`NewArticleForm`/`RecEditForm`). 
- Add "self-rec" badge in `RecCard`.
- Add "self-rec" badge in email digest's `RecCard`.

## Screenshots

![Screenshot 2024-09-09 at 2 34 39 PM](https://github.com/user-attachments/assets/3c7d63d1-773b-439c-8a78-5060723e0131)

![Screenshot 2024-09-09 at 2 35 02 PM](https://github.com/user-attachments/assets/3a8d8bf5-a8f4-43bf-b3d2-263a2d5f2af1)

Email digest:

![Screenshot 2024-09-09 at 10 35 16 PM](https://github.com/user-attachments/assets/e10d4934-c9ab-4820-a3ed-64d997d8b712)



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #271 
- #270 
- #272 

## Notes

<!-- Other thing to say -->

## Test

- Try create a "self-rec" using rec form
- Try to toggle the "isSelfRec" option while editing the rec

## TODO

- [x] Paste the testing link: https://recnet-bvmtlsnc2-recnet-542617e7.vercel.app/feeds
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
