### PR TITLE
[recnet-api] Allow deactivated user get user info

### DIFF
--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -93,7 +93,7 @@ export class UserController {
   @ApiOkResponse({ type: GetUsersResponse })
   @ApiBearerAuth()
   @Get("me")
-  @Auth()
+  @Auth({ allowNonActivated: true })
   public async getMe(@User() authUser: AuthUser): Promise<GetUserMeResponse> {
     const { userId } = authUser;
     const user = await this.userService.getUser(userId);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Allow deactivated user use `GET /users/me` to get user data.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## Test

- Turn a user to deactivated (either by overwrite using prisma studio or via API)
- Try to use `GET /users/me`
- Should get user data

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
