### PR TITLE
[recnet-api][v.1.4.2] Allow deactivated user get user info

### DIFF
--- a/apps/recnet-api/package.json
+++ b/apps/recnet-api/package.json
@@ -1,4 +1,4 @@
 {
   "name": "recnet-api",
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/apps/recnet-api/package.json
+++ b/apps/recnet-api/package.json
@@ -1,4 +1,4 @@
 {
   "name": "recnet-api",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -93,7 +93,7 @@ export class UserController {
   @ApiOkResponse({ type: GetUsersResponse })
   @ApiBearerAuth()
   @Get("me")
-  @Auth()
+  @Auth({ allowNonActivated: true })
   public async getMe(@User() authUser: AuthUser): Promise<GetUserMeResponse> {
     const { userId } = authUser;
     const user = await this.userService.getUser(userId);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #288 

## Notes

<!-- Other thing to say -->

## Test

- Turn a user to deactivated (via API)
- Try to use `GET /users/me`
- Should get user data

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
