### PR TITLE
[recnet-web][v.1.12.0] Deactivate account feature

### DIFF
--- a/apps/recnet/CHANGELOG.md
+++ b/apps/recnet/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.12.0](https://github.com/lil-lab/recnet/compare/recnet-web-v1.11.1...recnet-web-v1.12.0) (2024-09-19)
+
+
+### Features
+
+* add account setting tab ([24636a5](https://github.com/lil-lab/recnet/commit/24636a51a73fda553afd221079ec3e5c7a31fe4d))
+* finish reactivate page and deactivate dialog ([6ba4d0d](https://github.com/lil-lab/recnet/commit/6ba4d0de8c5c44bf267f7e248f3c4e9150821d21))
+
+
+### Bug Fixes
+
+* allow deactivated user get user info ([fa93f9b](https://github.com/lil-lab/recnet/commit/fa93f9bcaba4c081a241b42d859c408eacd6edb2))
+* restrict deactivated user's action ([48c4f25](https://github.com/lil-lab/recnet/commit/48c4f25674b8d8dfb56bbd6b38ac316af5dbea71))
+
 ## [1.11.1](https://github.com/lil-lab/recnet/compare/recnet-web-v1.11.0...recnet-web-v1.11.1) (2024-09-12)
 
 

--- a/apps/recnet/package.json
+++ b/apps/recnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recnet",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "commit-and-tag-version": {
     "skip": {
       "commit": true

--- a/apps/recnet/src/app/AuthContext.ts
+++ b/apps/recnet/src/app/AuthContext.ts
@@ -4,7 +4,7 @@ import { User } from "@recnet/recnet-api-model";
 
 export interface AuthContextValue {
   user: User | null;
-  revalidateUser: () => void;
+  revalidateUser: () => Promise<void>;
   isPending: boolean;
   isFetching: boolean;
   isError: boolean;

--- a/apps/recnet/src/app/[handle]/Profile.tsx
+++ b/apps/recnet/src/app/[handle]/Profile.tsx
@@ -1,21 +1,9 @@
 "use client";
 
-import { zodResolver } from "@hookform/resolvers/zod";
 import { HomeIcon, Link2Icon } from "@radix-ui/react-icons";
-import {
-  Dialog,
-  Button,
-  Flex,
-  Text,
-  TextField,
-  TextArea,
-} from "@radix-ui/themes";
-import { TRPCClientError } from "@trpc/client";
+import { Button, Flex, Text } from "@radix-ui/themes";
 import { useRouter } from "next/navigation";
-import React, { useMemo, useState } from "react";
-import { useForm, useFormState } from "react-hook-form";
-import { toast } from "sonner";
-import * as z from "zod";
+import React, { useMemo } from "react";
 
 import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { trpc } from "@recnet/recnet-web/app/_trpc/client";
@@ -23,318 +11,10 @@ import { Avatar } from "@recnet/recnet-web/components/Avatar";
 import { FollowButton } from "@recnet/recnet-web/components/FollowButton";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
 import { Skeleton, SkeletonText } from "@recnet/recnet-web/components/Skeleton";
-import { ErrorMessages } from "@recnet/recnet-web/constant";
 import { cn } from "@recnet/recnet-web/utils/cn";
 import { interleaveWithValue } from "@recnet/recnet-web/utils/interleaveWithValue";
 
-const HandleBlacklist = [
-  "about",
-  "api",
-  "all-users",
-  "feeds",
-  "help",
-  "onboard",
-  "search",
-  "user",
-];
-
-const EditUserProfileSchema = z.object({
-  displayName: z.string().min(1, "Name cannot be blank."),
-  handle: z
-    .string()
-    .min(4)
-    .max(15)
-    .regex(
-      /^[A-Za-z0-9_]+$/,
-      "User handle should be between 4 to 15 characters and contain only letters (A-Z, a-z), numbers, and underscores (_)."
-    )
-    .refine(
-      (name) => {
-        return !HandleBlacklist.includes(name);
-      },
-      {
-        message: "User handle is not allowed.",
-      }
-    ),
-  affiliation: z
-    .string()
-    .max(64, "Affiliation must contain at most 64 character(s)")
-    .nullable(),
-  bio: z
-    .string()
-    .max(200, "Bio must contain at most 200 character(s)")
-    .nullable(),
-  url: z.string().url().nullable(),
-  googleScholarLink: z.string().url().nullable(),
-  semanticScholarLink: z.string().url().nullable(),
-  openReviewUserName: z.string().nullable(),
-});
-
-function EditProfileDialog(props: { handle: string }) {
-  const { handle } = props;
-  const utils = trpc.useUtils();
-  const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const { user, revalidateUser } = useAuth();
-
-  const { register, handleSubmit, formState, setError, control, watch } =
-    useForm({
-      resolver: zodResolver(EditUserProfileSchema),
-      defaultValues: {
-        displayName: user?.displayName ?? null,
-        handle: user?.handle ?? null,
-        affiliation: user?.affiliation ?? null,
-        bio: user?.bio ?? null,
-        url: user?.url ?? null,
-        googleScholarLink: user?.googleScholarLink ?? null,
-        semanticScholarLink: user?.semanticScholarLink ?? null,
-        openReviewUserName: user?.openReviewUserName ?? null,
-      },
-      mode: "onTouched",
-    });
-  const { isDirty } = useFormState({ control: control });
-
-  const updateProfileMutation = trpc.updateUser.useMutation();
-
-  return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger>
-        <Button className="w-full cursor-pointer" variant="surface">
-          Edit profile
-        </Button>
-      </Dialog.Trigger>
-      <Dialog.Content style={{ maxWidth: 450 }}>
-        <form
-          onSubmit={handleSubmit(async (data, e) => {
-            e?.preventDefault();
-            const res = EditUserProfileSchema.safeParse(data);
-            if (!res.success || !user?.id) {
-              // should not happen, just in case and for typescript to narrow down type
-              console.error("Invalid form data.");
-              return;
-            }
-            // if no changes, close dialog
-            if (!isDirty) {
-              setOpen(false);
-              return;
-            }
-            try {
-              const oldHandle = user.handle;
-              const updatedData = await updateProfileMutation.mutateAsync(
-                {
-                  ...res.data,
-                },
-                {
-                  onError: (error) => {
-                    if (
-                      error instanceof TRPCClientError &&
-                      error.data.code === "CONFLICT" &&
-                      error.message === ErrorMessages.USER_HANDLE_USED
-                    ) {
-                      setError("handle", {
-                        type: "manual",
-                        message: "User handle already exists.",
-                      });
-                    }
-                  },
-                }
-              );
-              toast.success("Profile updated successfully!");
-              // revaildate user profile
-              revalidateUser();
-              if (updatedData.user.handle !== oldHandle) {
-                // if user change user handle, redirect to new user profile
-                router.replace(`/${updatedData.user.handle}`);
-              } else {
-                utils.getUserByHandle.invalidate({ handle: handle });
-                setOpen(false);
-              }
-            } catch (error) {
-              console.log(error);
-            }
-          })}
-        >
-          <Dialog.Title>Edit profile</Dialog.Title>
-          <Dialog.Description size="2" mb="4">
-            Make changes to your profile.
-          </Dialog.Description>
-
-          <Flex direction="column" gap="3">
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                Name
-              </Text>
-              <TextField.Root
-                placeholder="Enter your name"
-                {...register("displayName")}
-              />
-              {formState.errors.displayName ? (
-                <Text size="1" color="red">
-                  {formState.errors.displayName.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                User Handle
-              </Text>
-              <TextField.Root
-                placeholder="Enter user handle"
-                {...register("handle")}
-              />
-              {formState.errors.handle ? (
-                <Text size="1" color="red">
-                  {formState.errors.handle.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                Affiliation
-              </Text>
-              <TextField.Root
-                placeholder="Enter your affiliation"
-                {...register("affiliation", {
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-              />
-              {formState.errors.affiliation ? (
-                <Text size="1" color="red">
-                  {formState.errors.affiliation.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                Personal Website
-              </Text>
-              <TextField.Root
-                placeholder="Personal website URL(Optional)"
-                {...register("url", {
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-              />
-              {formState.errors.url ? (
-                <Text size="1" color="red">
-                  {formState.errors.url.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                <RecNetLink href="https://scholar.google.com/">
-                  Google Scholar
-                </RecNetLink>{" "}
-                Link
-              </Text>
-              <TextField.Root
-                placeholder="Google Scholar Link(Optional)"
-                {...register("googleScholarLink", {
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-              />
-              {formState.errors.googleScholarLink ? (
-                <Text size="1" color="red">
-                  {formState.errors.googleScholarLink.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                <RecNetLink href="https://www.semanticscholar.org/">
-                  Semantic Scholar
-                </RecNetLink>{" "}
-                Link
-              </Text>
-              <TextField.Root
-                placeholder="Semantic Scholar Link(Optional)"
-                {...register("semanticScholarLink", {
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-              />
-              {formState.errors.semanticScholarLink ? (
-                <Text size="1" color="red">
-                  {formState.errors.semanticScholarLink.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                <RecNetLink href="https://openreview.net/">
-                  OpenReview
-                </RecNetLink>{" "}
-                Username
-              </Text>
-              <TextField.Root
-                placeholder="OpenReview Username(Optional)"
-                {...register("openReviewUserName", {
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-              />
-              {formState.errors.openReviewUserName ? (
-                <Text size="1" color="red">
-                  {formState.errors.openReviewUserName.message}
-                </Text>
-              ) : null}
-            </label>
-            <label>
-              <Text as="div" size="2" mb="1" weight="medium">
-                Bio
-              </Text>
-              <TextArea
-                placeholder="Enter your bio"
-                {...register("bio", {
-                  onChange: () => {
-                    if ((watch("bio")?.length ?? 0) > 200) {
-                      setError("bio", {
-                        type: "manual",
-                        message: "Bio must contain at most 200 character(s)",
-                      });
-                    }
-                  },
-                  setValueAs: (val) => (val === "" ? null : val),
-                })}
-                className="h-[100px]"
-              />
-              <Flex className="justify-end p-1">
-                {formState.errors.bio ? (
-                  <Text size="1" color="red" className="mr-auto">
-                    {formState.errors.bio.message}
-                  </Text>
-                ) : (
-                  <></>
-                )}
-                <Text size="1" color="gray">
-                  {watch("bio")?.length || 0}/200
-                </Text>
-              </Flex>
-            </label>
-          </Flex>
-
-          <Flex gap="3" mt="4" justify="end">
-            <Dialog.Close>
-              <Button variant="soft" color="gray" className="cursor-pointer">
-                Cancel
-              </Button>
-            </Dialog.Close>
-            <Button
-              variant="solid"
-              color="blue"
-              className={cn("cursor-pointer", {
-                "bg-blue-10": formState.isValid,
-                "bg-gray-5": !formState.isValid,
-              })}
-              type="submit"
-              disabled={!formState.isValid}
-            >
-              Save
-            </Button>
-          </Flex>
-        </form>
-      </Dialog.Content>
-    </Dialog.Root>
-  );
-}
+import { UserSettingDialog } from "./UserSettingDialog";
 
 function StatDivider() {
   return <div className="w-[1px] bg-gray-6 h-[18px] flex" />;
@@ -504,7 +184,7 @@ export function Profile(props: { handle: string }) {
             </Flex>
             <Flex className="w-fit hidden md:flex">
               {isMe ? (
-                <EditProfileDialog handle={data.user.handle} />
+                <UserSettingDialog handle={data.user.handle} />
               ) : (
                 <FollowButton user={data.user} />
               )}
@@ -516,7 +196,7 @@ export function Profile(props: { handle: string }) {
       <div className="sm:hidden">{userInfo}</div>
       <Flex className="w-full md:hidden">
         {isMe ? (
-          <EditProfileDialog handle={data.user.handle} />
+          <UserSettingDialog handle={data.user.handle} />
         ) : (
           <FollowButton user={data.user} />
         )}

--- a/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
+++ b/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { PersonIcon, Cross1Icon } from "@radix-ui/react-icons";
 import {
   Dialog,
   Button,
@@ -10,6 +11,7 @@ import {
   TextArea,
 } from "@radix-ui/themes";
 import { TRPCClientError } from "@trpc/client";
+import { Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 import React, { useMemo, useState } from "react";
 import { useForm, useFormState } from "react-hook-form";
@@ -331,13 +333,15 @@ function AccountSetting(props: TabProps) {
 }
 
 const tabs = {
-  ACCOUNT: {
-    label: "Account",
-    component: AccountSetting,
-  },
   PROFILE: {
     label: "Profile",
+    icon: <PersonIcon />,
     component: EditProfileForm,
+  },
+  ACCOUNT: {
+    label: "Account",
+    icon: <Settings className="w-[15px] h-[15px]" />,
+    component: AccountSetting,
   },
 } as const;
 type TabKey = keyof typeof tabs;
@@ -388,25 +392,39 @@ export function UserSettingDialog(props: { handle: string }) {
           initial: "480px",
           md: "640px",
         }}
+        className="relative"
       >
-        <div className="flex flex-row gap-x-8 p-4">
+        <Dialog.Close className="absolute top-6 right-4 hidden md:block">
+          <Button variant="soft" color="gray" className="cursor-pointer">
+            <Cross1Icon />
+          </Button>
+        </Dialog.Close>
+        <div className="flex flex-row gap-x-8 md:p-4">
           <div className="w-fit md:w-[25%] flex flex-col gap-y-2">
             {Object.entries(tabs).map(([key, { label }]) => (
               <div
                 key={key}
                 className={cn(
-                  "py-1 px-4 rounded-2 flex items-center cursor-pointer hover:bg-gray-4",
+                  "py-1 px-4 rounded-2 flex gap-x-2 items-center cursor-pointer hover:bg-gray-4",
                   {
                     "bg-gray-5": key === activeTab,
                   }
                 )}
                 onClick={() => setActiveTab(key as TabKey)}
               >
-                <Text size="2">{label}</Text>
+                {tabs[key as TabKey].icon}
+                <Text
+                  size={{
+                    initial: "1",
+                    md: "2",
+                  }}
+                >
+                  {label}
+                </Text>
               </div>
             ))}
           </div>
-          <div className="w-full h-[600px] md:h-[700px] overflow-y-auto">
+          <div className="w-full h-[600px] md:h-[750px] overflow-y-auto">
             <TabComponent {...tabsProps[activeTab]} />
           </div>
         </div>

--- a/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
+++ b/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  Button,
+  Flex,
+  Text,
+  TextField,
+  TextArea,
+} from "@radix-ui/themes";
+import { TRPCClientError } from "@trpc/client";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import { useForm, useFormState } from "react-hook-form";
+import { toast } from "sonner";
+import * as z from "zod";
+
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
+import { trpc } from "@recnet/recnet-web/app/_trpc/client";
+import { RecNetLink } from "@recnet/recnet-web/components/Link";
+import { ErrorMessages } from "@recnet/recnet-web/constant";
+import { cn } from "@recnet/recnet-web/utils/cn";
+
+import { User } from "@recnet/recnet-api-model";
+
+const HandleBlacklist = [
+  "about",
+  "api",
+  "all-users",
+  "feeds",
+  "help",
+  "onboard",
+  "search",
+  "user",
+];
+
+const EditUserProfileSchema = z.object({
+  displayName: z.string().min(1, "Name cannot be blank."),
+  handle: z
+    .string()
+    .min(4)
+    .max(15)
+    .regex(
+      /^[A-Za-z0-9_]+$/,
+      "User handle should be between 4 to 15 characters and contain only letters (A-Z, a-z), numbers, and underscores (_)."
+    )
+    .refine(
+      (name) => {
+        return !HandleBlacklist.includes(name);
+      },
+      {
+        message: "User handle is not allowed.",
+      }
+    ),
+  affiliation: z
+    .string()
+    .max(64, "Affiliation must contain at most 64 character(s)")
+    .nullable(),
+  bio: z
+    .string()
+    .max(200, "Bio must contain at most 200 character(s)")
+    .nullable(),
+  url: z.string().url().nullable(),
+  googleScholarLink: z.string().url().nullable(),
+  semanticScholarLink: z.string().url().nullable(),
+  openReviewUserName: z.string().nullable(),
+});
+
+function EditProfileForm(props: {
+  onSuccess?: (user: User) => void;
+  setOpen: (open: boolean) => void;
+}) {
+  const { onSuccess = () => {}, setOpen } = props;
+  const { user, revalidateUser } = useAuth();
+
+  const { register, handleSubmit, formState, setError, control, watch } =
+    useForm({
+      resolver: zodResolver(EditUserProfileSchema),
+      defaultValues: {
+        displayName: user?.displayName ?? null,
+        handle: user?.handle ?? null,
+        affiliation: user?.affiliation ?? null,
+        bio: user?.bio ?? null,
+        url: user?.url ?? null,
+        googleScholarLink: user?.googleScholarLink ?? null,
+        semanticScholarLink: user?.semanticScholarLink ?? null,
+        openReviewUserName: user?.openReviewUserName ?? null,
+      },
+      mode: "onTouched",
+    });
+  const { isDirty } = useFormState({ control: control });
+
+  const updateProfileMutation = trpc.updateUser.useMutation();
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (data, e) => {
+        e?.preventDefault();
+        const res = EditUserProfileSchema.safeParse(data);
+        if (!res.success || !user?.id) {
+          // should not happen, just in case and for typescript to narrow down type
+          console.error("Invalid form data.");
+          return;
+        }
+        // if no changes, close dialog
+        if (!isDirty) {
+          setOpen(false);
+          return;
+        }
+        try {
+          const updatedData = await updateProfileMutation.mutateAsync(
+            {
+              ...res.data,
+            },
+            {
+              onError: (error) => {
+                if (
+                  error instanceof TRPCClientError &&
+                  error.data.code === "CONFLICT" &&
+                  error.message === ErrorMessages.USER_HANDLE_USED
+                ) {
+                  setError("handle", {
+                    type: "manual",
+                    message: "User handle already exists.",
+                  });
+                }
+              },
+            }
+          );
+          toast.success("Profile updated successfully!");
+          // revaildate user profile
+          revalidateUser();
+          // fire onSuccess callback
+          onSuccess(updatedData.user);
+        } catch (error) {
+          console.log(error);
+        }
+      })}
+    >
+      <Dialog.Title>Edit profile</Dialog.Title>
+      <Dialog.Description size="2" mb="4">
+        Make changes to your profile.
+      </Dialog.Description>
+
+      <Flex direction="column" gap="3">
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            Name
+          </Text>
+          <TextField.Root
+            placeholder="Enter your name"
+            {...register("displayName")}
+          />
+          {formState.errors.displayName ? (
+            <Text size="1" color="red">
+              {formState.errors.displayName.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            User Handle
+          </Text>
+          <TextField.Root
+            placeholder="Enter user handle"
+            {...register("handle")}
+          />
+          {formState.errors.handle ? (
+            <Text size="1" color="red">
+              {formState.errors.handle.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            Affiliation
+          </Text>
+          <TextField.Root
+            placeholder="Enter your affiliation"
+            {...register("affiliation", {
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+          />
+          {formState.errors.affiliation ? (
+            <Text size="1" color="red">
+              {formState.errors.affiliation.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            Personal Website
+          </Text>
+          <TextField.Root
+            placeholder="Personal website URL(Optional)"
+            {...register("url", {
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+          />
+          {formState.errors.url ? (
+            <Text size="1" color="red">
+              {formState.errors.url.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            <RecNetLink href="https://scholar.google.com/">
+              Google Scholar
+            </RecNetLink>{" "}
+            Link
+          </Text>
+          <TextField.Root
+            placeholder="Google Scholar Link(Optional)"
+            {...register("googleScholarLink", {
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+          />
+          {formState.errors.googleScholarLink ? (
+            <Text size="1" color="red">
+              {formState.errors.googleScholarLink.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            <RecNetLink href="https://www.semanticscholar.org/">
+              Semantic Scholar
+            </RecNetLink>{" "}
+            Link
+          </Text>
+          <TextField.Root
+            placeholder="Semantic Scholar Link(Optional)"
+            {...register("semanticScholarLink", {
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+          />
+          {formState.errors.semanticScholarLink ? (
+            <Text size="1" color="red">
+              {formState.errors.semanticScholarLink.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            <RecNetLink href="https://openreview.net/">OpenReview</RecNetLink>{" "}
+            Username
+          </Text>
+          <TextField.Root
+            placeholder="OpenReview Username(Optional)"
+            {...register("openReviewUserName", {
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+          />
+          {formState.errors.openReviewUserName ? (
+            <Text size="1" color="red">
+              {formState.errors.openReviewUserName.message}
+            </Text>
+          ) : null}
+        </label>
+        <label>
+          <Text as="div" size="2" mb="1" weight="medium">
+            Bio
+          </Text>
+          <TextArea
+            placeholder="Enter your bio"
+            {...register("bio", {
+              onChange: () => {
+                if ((watch("bio")?.length ?? 0) > 200) {
+                  setError("bio", {
+                    type: "manual",
+                    message: "Bio must contain at most 200 character(s)",
+                  });
+                }
+              },
+              setValueAs: (val) => (val === "" ? null : val),
+            })}
+            className="h-[100px]"
+          />
+          <Flex className="justify-end p-1">
+            {formState.errors.bio ? (
+              <Text size="1" color="red" className="mr-auto">
+                {formState.errors.bio.message}
+              </Text>
+            ) : (
+              <></>
+            )}
+            <Text size="1" color="gray">
+              {watch("bio")?.length || 0}/200
+            </Text>
+          </Flex>
+        </label>
+      </Flex>
+
+      <Flex gap="3" mt="4" justify="end">
+        <Dialog.Close>
+          <Button variant="soft" color="gray" className="cursor-pointer">
+            Cancel
+          </Button>
+        </Dialog.Close>
+        <Button
+          variant="solid"
+          color="blue"
+          className={cn("cursor-pointer", {
+            "bg-blue-10": formState.isValid,
+            "bg-gray-5": !formState.isValid,
+          })}
+          type="submit"
+          disabled={!formState.isValid}
+        >
+          Save
+        </Button>
+      </Flex>
+    </form>
+  );
+}
+
+export function UserSettingDialog(props: { handle: string }) {
+  const { handle } = props;
+  const utils = trpc.useUtils();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const { user } = useAuth();
+  const oldHandle = user?.handle;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger>
+        <Button className="w-full cursor-pointer" variant="surface">
+          Edit profile
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content style={{ maxWidth: 450 }}>
+        <EditProfileForm
+          onSuccess={(updatedUser) => {
+            if (updatedUser.handle !== oldHandle) {
+              // if user change user handle, redirect to new user profile
+              router.replace(`/${updatedUser.handle}`);
+            } else {
+              utils.getUserByHandle.invalidate({ handle: handle });
+              setOpen(false);
+            }
+          }}
+          setOpen={setOpen}
+        />
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
+++ b/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
@@ -20,6 +20,7 @@ import * as z from "zod";
 
 import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { trpc } from "@recnet/recnet-web/app/_trpc/client";
+import { DoubleConfirmButton } from "@recnet/recnet-web/components/DoubleConfirmButton";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
 import { ErrorMessages } from "@recnet/recnet-web/constant";
 import { cn } from "@recnet/recnet-web/utils/cn";
@@ -326,8 +327,33 @@ function AccountSetting(props: TabProps) {
     <div>
       <Dialog.Title>Account Setting</Dialog.Title>
       <Dialog.Description size="2" mb="4">
-        Make changes to account.
+        Make changes to account settings.
       </Dialog.Description>
+
+      <Text size="4" color="red" className="block">
+        Deactivate Account
+      </Text>
+      <Text size="1" className="text-gray-11 block">
+        {
+          "Your account will be deactivated and you will be logged out. You can reactivate your account by logging in again."
+        }
+        {
+          " While your account is deactivated, your profile will be hidden from other users. You will not receive any weekly digest emails."
+        }
+      </Text>
+      <div className="flex flex-row w-full mt-4">
+        <DoubleConfirmButton
+          onConfirm={async () => {
+            // TODO: deactivate account
+          }}
+          title="Deactivate Account"
+          description="Are you sure you want to deactivate your account?"
+        >
+          <Button color="red" className="bg-red-10 cursor-pointer">
+            Deactivate Account
+          </Button>
+        </DoubleConfirmButton>
+      </div>
     </div>
   );
 }

--- a/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
+++ b/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
@@ -23,6 +23,7 @@ import { trpc } from "@recnet/recnet-web/app/_trpc/client";
 import { DoubleConfirmButton } from "@recnet/recnet-web/components/DoubleConfirmButton";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
 import { ErrorMessages } from "@recnet/recnet-web/constant";
+import { logout } from "@recnet/recnet-web/firebase/auth";
 import { cn } from "@recnet/recnet-web/utils/cn";
 
 import { User } from "@recnet/recnet-api-model";
@@ -323,6 +324,9 @@ function EditProfileForm(props: TabProps) {
 }
 
 function AccountSetting(props: TabProps) {
+  const deactivateMutation = trpc.deactivate.useMutation();
+  const { onSuccess = () => {} } = props;
+
   return (
     <div>
       <Dialog.Title>Account Setting</Dialog.Title>
@@ -344,7 +348,9 @@ function AccountSetting(props: TabProps) {
       <div className="flex flex-row w-full mt-4">
         <DoubleConfirmButton
           onConfirm={async () => {
-            // TODO: deactivate account
+            const { user } = await deactivateMutation.mutateAsync();
+            await logout();
+            onSuccess(user);
           }}
           title="Deactivate Account"
           description="Are you sure you want to deactivate your account?"
@@ -384,7 +390,8 @@ export function UserSettingDialog(props: { handle: string }) {
     return {
       ACCOUNT: {
         onSuccess: (updatedUser: User) => {
-          console.log(updatedUser);
+          // redirect to home page after deactivating account
+          router.replace("/");
         },
         setOpen: setOpen,
       },

--- a/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
+++ b/apps/recnet/src/app/[handle]/UserSettingDialog.tsx
@@ -417,7 +417,7 @@ export function UserSettingDialog(props: { handle: string }) {
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger>
         <Button className="w-full cursor-pointer" variant="surface">
-          Edit profile
+          Settings
         </Button>
       </Dialog.Trigger>
       <Dialog.Content

--- a/apps/recnet/src/app/[handle]/page.tsx
+++ b/apps/recnet/src/app/[handle]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { serverClient } from "@recnet/recnet-web/app/_trpc/serverClient";
 import { cn } from "@recnet/recnet-web/utils/cn";
@@ -12,6 +12,14 @@ export default async function UserProfilePage({
   params: { handle: string };
 }) {
   const { handle } = params;
+  /*
+    Check if deactivated user access their profile
+  */
+  const { user: me } = await serverClient.getMe();
+  if (me?.handle === handle && me?.isActivated === false) {
+    redirect("/reactivate");
+  }
+
   const { user } = await serverClient.getUserByHandle({
     handle,
   });

--- a/apps/recnet/src/app/reactivate/ReactivateButton.tsx
+++ b/apps/recnet/src/app/reactivate/ReactivateButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Button } from "@radix-ui/themes";
+import { trpc } from "@recnet/recnet-web/app/_trpc/client";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export function ReactivateButton() {
+  const [isLoading, setIsLoading] = useState(false);
+  const activateMutation = trpc.activate.useMutation();
+  const router = useRouter();
+  const { revalidateUser } = useAuth();
+
+  const onClick = async () => {
+    setIsLoading(true);
+    await activateMutation.mutateAsync();
+    await revalidateUser();
+    setTimeout(() => {
+      toast.success("Welcome back! Redirecting...");
+      router.push("/feeds");
+      setIsLoading(false);
+    }, 1000);
+  };
+
+  return (
+    <Button
+      className="cursor-pointer"
+      disabled={isLoading}
+      loading={isLoading}
+      onClick={onClick}
+    >
+      Reactivate
+    </Button>
+  );
+}

--- a/apps/recnet/src/app/reactivate/ReactivateButton.tsx
+++ b/apps/recnet/src/app/reactivate/ReactivateButton.tsx
@@ -19,7 +19,7 @@ export function ReactivateButton() {
     await revalidateUser();
     setTimeout(() => {
       toast.success("Welcome back! Redirecting...");
-      router.push("/feeds");
+      router.refresh();
       setIsLoading(false);
     }, 1000);
   };

--- a/apps/recnet/src/app/reactivate/page.tsx
+++ b/apps/recnet/src/app/reactivate/page.tsx
@@ -1,0 +1,47 @@
+import { Text } from "@radix-ui/themes";
+import { redirect } from "next/navigation";
+
+import { Avatar } from "@recnet/recnet-web/components/Avatar";
+import { cn } from "@recnet/recnet-web/utils/cn";
+import { getUserServerSide } from "@recnet/recnet-web/utils/getUserServerSide";
+import { ReactivateButton } from "./ReactivateButton";
+
+export default async function ReactivatePage() {
+  const user = await getUserServerSide({
+    notRegisteredCallback: () => {
+      redirect("/onboard");
+    },
+  });
+  if (!user) {
+    redirect("/");
+  }
+  // only deactivated users can access this page
+  if (user.isActivated) {
+    redirect("/feeds");
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full",
+        "lg:w-[60%]",
+        `min-h-[90svh]`,
+        "flex",
+        "flex-col",
+        "justify-center",
+        "items-center",
+        "gap-y-6",
+        "py-8",
+        "px-4"
+      )}
+    >
+      <Avatar user={user} size={"6"} />
+      <Text size="4"> Welcome back, {user.displayName}!</Text>
+      <Text size="3" className="w-[300px] text-center text-gray-11">
+        Your account is currently deactivated. Reactivate your account to
+        continue using Recnet.
+      </Text>
+      <ReactivateButton />
+    </div>
+  );
+}

--- a/apps/recnet/src/components/FollowButton.tsx
+++ b/apps/recnet/src/components/FollowButton.tsx
@@ -32,6 +32,10 @@ export function FollowButton(props: FollowButtonProps) {
           toast.error("You must be logged in to follow someone.");
           return;
         }
+        if (me.isActivated === false) {
+          toast.error("Your account is currently deactivated.");
+          return;
+        }
         setIsLoading(true);
         if (isFollowing) {
           try {

--- a/apps/recnet/src/components/hoc/withAuthRequired.tsx
+++ b/apps/recnet/src/components/hoc/withAuthRequired.tsx
@@ -56,6 +56,13 @@ export async function withAuthRequired<T extends object>(
   }
 
   /**
+    Handle deactivated users.
+  */
+  if (user.isActivated === false) {
+    redirect("/reactivate");
+  }
+
+  /**
     Handle prohibited roles.
   */
   if (options?.prohibitedRoles) {

--- a/apps/recnet/src/server/routers/user.ts
+++ b/apps/recnet/src/server/routers/user.ts
@@ -17,6 +17,8 @@ import {
   postUserMeRequestSchema,
   postUserMeResponseSchema,
   getStatsResponseSchema,
+  patchUserMeActivateRequestSchema,
+  patchUserMeActivateResponseSchema,
 } from "@recnet/recnet-api-model";
 
 import {
@@ -178,6 +180,28 @@ export const userRouter = router({
           userId,
         },
       });
+    }),
+  deactivate: checkRecnetJWTProcedure
+    .output(patchUserMeActivateResponseSchema)
+    .mutation(async (opts) => {
+      const { recnetApi } = opts.ctx;
+      const { data } = await recnetApi.patch("/users/me/activate", {
+        ...patchUserMeActivateRequestSchema.parse({
+          isActivated: false,
+        }),
+      });
+      return patchUserMeActivateResponseSchema.parse(data);
+    }),
+  activate: checkRecnetJWTProcedure
+    .output(patchUserMeActivateResponseSchema)
+    .mutation(async (opts) => {
+      const { recnetApi } = opts.ctx;
+      const { data } = await recnetApi.patch("/users/me/activate", {
+        ...patchUserMeActivateRequestSchema.parse({
+          isActivated: true,
+        }),
+      });
+      return patchUserMeActivateResponseSchema.parse(data);
     }),
   getNumOfUsers: checkIsAdminProcedure
     .output(z.object({ num: z.number() }))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Design docs: https://www.notion.so/Deactivate-Account-6f43ae29772442e293d8f0d9641d2be1?pvs=4

- Extend `EditProfileDialog` to `UserSettingDialog`
- Add deactivate button to `UserSettingDialog`
- Add `/reactivate` page (deactivated user will be directed to this page after logging in)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #90 

## Notes

<!-- Other thing to say -->

## Screenshots

New component: `UserSettingDialog` (extend from prev `EditProfileDialog`)
![Screenshot 2024-09-14 at 7 46 37 PM](https://github.com/user-attachments/assets/1e121059-44b5-443d-a0ad-9d151b7dfabf)
![Screenshot 2024-09-14 at 7 46 49 PM](https://github.com/user-attachments/assets/b0ecf80e-3910-4361-9e05-a9f03200628b)

`/reactivate` page
![Screenshot 2024-09-14 at 7 47 21 PM](https://github.com/user-attachments/assets/9986d4ee-c8d9-47c5-af10-49e12698b679)

## Test

Try to deactivate and reactivate. When deactivated, actions like follow someone should be disallowed. And user should not appear in search result.


## TODO

- [x] Paste the testing link: https://recnet-owi30z4xr-recnet-542617e7.vercel.app/?vercelToolbarCode=c2FjQ9NjBpfC0eA
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
