### PR TITLE
[recnet-web][v.1.13.0] Add new onboarding step

### DIFF
--- a/apps/recnet/src/app/[handle]/HistoricalRecs.tsx
+++ b/apps/recnet/src/app/[handle]/HistoricalRecs.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { Text } from "@radix-ui/themes";
-import { InfiniteData } from "@tanstack/react-query";
 import { useMemo } from "react";
 import InfiniteScroll from "react-infinite-scroll-component";
 
@@ -8,24 +7,11 @@ import {
   RecCard,
   RecCardSkeleton,
 } from "@recnet/recnet-web/components/RecCard";
-
-import { GetRecsResponse } from "@recnet/recnet-api-model";
-import { Rec } from "@recnet/recnet-api-model";
+import { getDataFromInfiniteQuery } from "@recnet/recnet-web/utils/getDataFromInfiniteQuery";
 
 import { trpc } from "../_trpc/client";
 
 const PAGE_SIZE = 5;
-
-const getHistoricalRecsFromInfiniteQuery = (
-  infiniteQueryData: InfiniteData<GetRecsResponse> | undefined
-) => {
-  if (!infiniteQueryData) {
-    return [];
-  }
-  return (infiniteQueryData?.pages ?? []).reduce((acc, page) => {
-    return [...acc, ...page.recs];
-  }, [] as Rec[]);
-};
 
 export function HistoricalRecs(props: { userId: string }) {
   const { userId } = props;
@@ -47,7 +33,14 @@ export function HistoricalRecs(props: { userId: string }) {
       }
     );
 
-  const recs = useMemo(() => getHistoricalRecsFromInfiniteQuery(data), [data]);
+  const recs = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return getDataFromInfiniteQuery(data, (page) => {
+      return page.recs;
+    });
+  }, [data]);
 
   if (isPending) {
     return (

--- a/apps/recnet/src/app/all-users/page.tsx
+++ b/apps/recnet/src/app/all-users/page.tsx
@@ -9,10 +9,11 @@ import { GoBackButton } from "@recnet/recnet-web/components/GoBackButton";
 import { LoadingBox } from "@recnet/recnet-web/components/LoadingBox";
 import { UserList } from "@recnet/recnet-web/components/UserCard";
 import { cn } from "@recnet/recnet-web/utils/cn";
+import { getDataFromInfiniteQuery } from "@recnet/recnet-web/utils/getDataFromInfiniteQuery";
+import { shuffleArray } from "@recnet/recnet-web/utils/shuffle";
 
 import { useAuth } from "../AuthContext";
 import { trpc } from "../_trpc/client";
-import { getShuffledUsersFromInfiniteQuery } from "../search/page";
 
 export default function SearchResultPage() {
   const { user } = useAuth();
@@ -33,10 +34,14 @@ export default function SearchResultPage() {
       }
     );
 
-  const users = useMemo(
-    () => getShuffledUsersFromInfiniteQuery(data, user?.id),
-    [data, user]
-  );
+  const users = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return getDataFromInfiniteQuery(data, (page) => {
+      return shuffleArray(page.users, user?.id || "");
+    });
+  }, [data, user]);
 
   if (isPending) {
     return <LoadingBox className="h-[95svh]" />;

--- a/apps/recnet/src/app/feeds/page.tsx
+++ b/apps/recnet/src/app/feeds/page.tsx
@@ -23,6 +23,7 @@ import { GetRecsFeedsResponse, Rec } from "@recnet/recnet-api-model";
 
 import { useAuth } from "../AuthContext";
 import { trpc } from "../_trpc/client";
+import { OnboardingDialog } from "../onboard/OnboardingDialog";
 
 const PAGE_SIZE = 5;
 
@@ -136,6 +137,7 @@ export default function FeedPage({
         "md:py-12"
       )}
     >
+      <OnboardingDialog />
       {Object.keys(recsGroupByTitle).length > 0 ? (
         <InfiniteScroll
           dataLength={Object.keys(recsGroupByTitle).length}

--- a/apps/recnet/src/app/onboard/OnboardingDialog.tsx
+++ b/apps/recnet/src/app/onboard/OnboardingDialog.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { Button, Dialog, Flex } from "@radix-ui/themes";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useEffect, useState, useMemo } from "react";
+import { useInView } from "react-intersection-observer";
+
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
+import { trpc } from "@recnet/recnet-web/app/_trpc/client";
+import { LoadingBox } from "@recnet/recnet-web/components/LoadingBox";
+import { UserList } from "@recnet/recnet-web/components/UserCard";
+import { getDataFromInfiniteQuery } from "@recnet/recnet-web/utils/getDataFromInfiniteQuery";
+import { shuffleArray } from "@recnet/recnet-web/utils/shuffle";
+
+export function OnboardingDialog() {
+  const [shouldShow, setShouldShow] = useState(false);
+  const searchParams = useSearchParams();
+  const { user } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const { ref: bottomRef, inView: bottomInView } = useInView({
+    threshold: 0,
+  });
+
+  useEffect(() => {
+    if (searchParams.get("onboarding") === "true") {
+      setShouldShow(true);
+    }
+  }, [searchParams]);
+
+  const { data, isPending, isFetching, fetchNextPage, hasNextPage } =
+    trpc.search.useInfiniteQuery(
+      {
+        keyword: "",
+        pageSize: 20,
+      },
+      {
+        getNextPageParam: (lastPage, allPages) => {
+          if (!lastPage.hasNext) {
+            return null;
+          }
+          return allPages.length + 1;
+        },
+        initialCursor: 1,
+      }
+    );
+
+  useEffect(() => {
+    if (hasNextPage && bottomInView) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, bottomInView, fetchNextPage]);
+
+  const users = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return getDataFromInfiniteQuery(data, (page) => {
+      return shuffleArray(page.users, user?.id || "");
+    });
+  }, [data, user]);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <Dialog.Root open={shouldShow} onOpenChange={setShouldShow}>
+      <Dialog.Content
+        maxWidth={{ initial: "450px", md: "700px" }}
+        style={{
+          maxHeight: "75vh",
+          padding: "0",
+        }}
+        onPointerDownOutside={(e) => {
+          // Prevent the dialog from closing when clicking outside
+          e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          // Prevent the dialog from closing when pressing escape
+          e.preventDefault();
+        }}
+      >
+        <div className="flex flex-col px-6 pb-6 pt-8">
+          <Dialog.Title>Welcome to RecNet! 🎊👋</Dialog.Title>
+          <Dialog.Description className="text-gray-11" size="2">
+            Before you start, expand your network by following other users!
+          </Dialog.Description>
+        </div>
+        {isPending ? (
+          <LoadingBox className="h-[200px]" />
+        ) : (
+          <div className="p-4 h-[50vh] overflow-y-auto overflow-x-hidden">
+            <UserList users={users} />
+            {isFetching ? <LoadingBox className="h-[200px]" /> : null}
+            <div ref={bottomRef} className="w-full h-1px bg-red-4" />
+          </div>
+        )}
+        <Flex className="justift-end py-4 px-6 border-t-[1px] border-gray-6">
+          <Button
+            className="ml-auto cursor-pointer"
+            onClick={() => {
+              setShouldShow(false);
+              router.replace(pathname);
+            }}
+          >
+            {(user?.following ?? []).length > 0 ? "Continue" : "Skip"}
+          </Button>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/apps/recnet/src/app/onboard/OnboardingDialog.tsx
+++ b/apps/recnet/src/app/onboard/OnboardingDialog.tsx
@@ -91,7 +91,7 @@ export function OnboardingDialog() {
           <LoadingBox className="h-[200px]" />
         ) : (
           <div className="p-4 h-[50vh] overflow-y-auto overflow-x-hidden">
-            <UserList users={users} />
+            <UserList users={users} hideMe />
             {isFetching ? <LoadingBox className="h-[200px]" /> : null}
             <div ref={bottomRef} className="w-full h-1px bg-red-4" />
           </div>

--- a/apps/recnet/src/app/onboard/page.tsx
+++ b/apps/recnet/src/app/onboard/page.tsx
@@ -165,7 +165,7 @@ export default function OnboardPage() {
           await revalidateUser();
           setMessage("You are all set! Redirecting...");
           // direct to /feeds
-          router.replace("/feeds");
+          router.replace("/feeds?onboarding=true");
           setIsLoading(false);
         })}
       >

--- a/apps/recnet/src/app/page.tsx
+++ b/apps/recnet/src/app/page.tsx
@@ -30,6 +30,9 @@ const cards = [
 
 export default async function Home() {
   await getUserServerSide({
+    notRegisteredCallback: () => {
+      redirect("/onboard");
+    },
     isLoggedInCallback: () => {
       redirect("/feeds");
     },

--- a/apps/recnet/src/components/UserCard.tsx
+++ b/apps/recnet/src/components/UserCard.tsx
@@ -3,6 +3,7 @@
 import { HomeIcon, Pencil1Icon, PersonIcon } from "@radix-ui/react-icons";
 import { Flex, Text, Grid, Tooltip } from "@radix-ui/themes";
 
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { Avatar } from "@recnet/recnet-web/components/Avatar";
 import { FollowButton } from "@recnet/recnet-web/components/FollowButton";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
@@ -10,7 +11,15 @@ import { cn } from "@recnet/recnet-web/utils/cn";
 
 import { UserPreview } from "@recnet/recnet-api-model";
 
-export function UserList({ users }: { users: UserPreview[] }) {
+export function UserList({
+  users,
+  hideMe = false,
+}: {
+  users: UserPreview[];
+  hideMe?: boolean;
+}) {
+  const { user: me } = useAuth();
+
   return (
     <Grid
       columns={{
@@ -20,9 +29,12 @@ export function UserList({ users }: { users: UserPreview[] }) {
       }}
       gap="4"
     >
-      {users.map((user, idx) => (
-        <UserCard key={`${user.handle}-${idx}`} user={user} />
-      ))}
+      {users.map((user, idx) => {
+        if (hideMe && !!me && me.id === user.id) {
+          return null;
+        }
+        return <UserCard key={`${user.handle}-${idx}`} user={user} />;
+      })}
     </Grid>
   );
 }

--- a/apps/recnet/src/utils/getDataFromInfiniteQuery.spec.ts
+++ b/apps/recnet/src/utils/getDataFromInfiniteQuery.spec.ts
@@ -1,0 +1,99 @@
+import { InfiniteData } from "@tanstack/react-query";
+import { describe, it, expect } from "vitest";
+
+import { getDataFromInfiniteQuery } from "./getDataFromInfiniteQuery";
+
+describe("getDataFromInfiniteQuery", () => {
+  it("should correctly map data from multiple pages", () => {
+    const mockInfiniteData: InfiniteData<number[]> = {
+      pages: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      pageParams: [null, 1, 2],
+    };
+
+    const result = getDataFromInfiniteQuery(mockInfiniteData, (page) => page);
+    expect(result).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("should handle complex data structures and custom mapping", () => {
+    interface ComplexData {
+      id: number;
+      items: string[];
+    }
+
+    const mockInfiniteData: InfiniteData<ComplexData> = {
+      pages: [
+        { id: 1, items: ["a", "b"] },
+        { id: 2, items: ["c", "d"] },
+        { id: 3, items: ["e", "f"] },
+      ],
+      pageParams: [null, 1, 2],
+    };
+
+    const result = getDataFromInfiniteQuery(
+      mockInfiniteData,
+      (page) => page.items
+    );
+    expect(result).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("should handle empty pages", () => {
+    const mockInfiniteData: InfiniteData<number[]> = {
+      pages: [[], [], []],
+      pageParams: [null, 1, 2],
+    };
+
+    const result = getDataFromInfiniteQuery(mockInfiniteData, (page) => page);
+    expect(result).toEqual([]);
+  });
+
+  it("should handle a mix of empty and non-empty pages", () => {
+    const mockInfiniteData: InfiniteData<number[]> = {
+      pages: [[1, 2], [], [5, 6], []],
+      pageParams: [null, 1, 2, 3],
+    };
+
+    const result = getDataFromInfiniteQuery(mockInfiniteData, (page) => page);
+    expect(result).toEqual([1, 2, 5, 6]);
+  });
+
+  it("should work with a custom mapper function", () => {
+    const mockInfiniteData: InfiniteData<number[]> = {
+      pages: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      pageParams: [null, 1, 2],
+    };
+
+    const customMapper = (page: number[]) => page.map((num) => num * 2);
+    const result = getDataFromInfiniteQuery(mockInfiniteData, customMapper);
+    expect(result).toEqual([2, 4, 6, 8, 10, 12]);
+  });
+
+  it("should preserve the structure returned by the mapper function", () => {
+    const mockInfiniteData: InfiniteData<number[]> = {
+      pages: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      pageParams: [null, 1, 2],
+    };
+
+    const structurePreservingMapper = (page: number[]) => [page];
+    const result = getDataFromInfiniteQuery(
+      mockInfiniteData,
+      structurePreservingMapper
+    );
+    expect(result).toEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+});

--- a/apps/recnet/src/utils/getDataFromInfiniteQuery.ts
+++ b/apps/recnet/src/utils/getDataFromInfiniteQuery.ts
@@ -1,0 +1,16 @@
+import { InfiniteData } from "@tanstack/react-query";
+
+/*
+ * This function is used to extract data from an infinite query.
+ * It takes the infiniteData and a dataMapper function as arguments.
+ * The dataMapper function is used to map the page data to the desired data.
+ */
+export function getDataFromInfiniteQuery<TPageData, TData>(
+  infiniteData: InfiniteData<TPageData>,
+  dataMapper: (pageData: TPageData) => TData[]
+) {
+  return infiniteData.pages.reduce((acc, page) => {
+    const nextBatch = dataMapper(page);
+    return [...acc, ...nextBatch];
+  }, [] as TData[]);
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add new onboarding flow. After new user fill all required information, there will be a dialog showing up to ask user to follow other uses. This dialog can be extend to multi-step onboarding guide in the future. Currently, just one step.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #83 

## Notes

<!-- Other thing to say -->

Also extract the replicated logic about transforming infinite query data by new utils function `getDataFromInfiniteQuery`.

## Test

Try to log in using a new account.
- Should see the onboarding dialog like this after finishing the registration form.
![Screenshot 2024-09-17 at 12 02 19 AM](https://github.com/user-attachments/assets/b4c87abd-9709-47ba-af04-c23145347b64)

## TODO

- [x] Paste the testing link: https://recnet-kgy60sanc-recnet-542617e7.vercel.app/
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
