### PR TITLE
[recnet-api] Add digital library CRUD APIs

### DIFF
--- a/apps/recnet-api/src/database/repository/digital-library.repository.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.ts
@@ -1,8 +1,12 @@
 import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 
 import PrismaConnectionProvider from "@recnet-api/database/prisma/prisma.connection.provider";
 
-import { digitalLibrary } from "./digital-library.repository.type";
+import {
+  digitalLibrary,
+  DigitalLibraryFilterBy,
+} from "./digital-library.repository.type";
 @Injectable()
 export default class DigitalLibraryRepository {
   constructor(private readonly prisma: PrismaConnectionProvider) {}
@@ -10,7 +14,7 @@ export default class DigitalLibraryRepository {
   public async findAll() {
     return this.prisma.digitalLibrary.findMany({
       orderBy: {
-        rank: "asc",
+        rank: Prisma.SortOrder.asc,
       },
       select: digitalLibrary.select,
     });
@@ -19,6 +23,13 @@ export default class DigitalLibraryRepository {
   public async findById(id: number) {
     return this.prisma.digitalLibrary.findUniqueOrThrow({
       where: { id },
+      select: digitalLibrary.select,
+    });
+  }
+
+  public async findDigitalLibraries(filter: DigitalLibraryFilterBy) {
+    return this.prisma.digitalLibrary.findMany({
+      where: filter,
       select: digitalLibrary.select,
     });
   }

--- a/apps/recnet-api/src/database/repository/digital-library.repository.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.ts
@@ -7,6 +7,7 @@ import {
   CreateDigitalLibraryInput,
   digitalLibrary,
   DigitalLibraryFilterBy,
+  UpdateDigitalLibraryInput,
 } from "./digital-library.repository.type";
 @Injectable()
 export default class DigitalLibraryRepository {
@@ -37,6 +38,14 @@ export default class DigitalLibraryRepository {
 
   public async create(data: CreateDigitalLibraryInput) {
     return this.prisma.digitalLibrary.create({
+      data,
+      select: digitalLibrary.select,
+    });
+  }
+
+  public async update(id: number, data: UpdateDigitalLibraryInput) {
+    return this.prisma.digitalLibrary.update({
+      where: { id },
       data,
       select: digitalLibrary.select,
     });

--- a/apps/recnet-api/src/database/repository/digital-library.repository.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.ts
@@ -50,4 +50,10 @@ export default class DigitalLibraryRepository {
       select: digitalLibrary.select,
     });
   }
+
+  public async delete(id: number) {
+    return this.prisma.digitalLibrary.delete({
+      where: { id },
+    });
+  }
 }

--- a/apps/recnet-api/src/database/repository/digital-library.repository.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import PrismaConnectionProvider from "@recnet-api/database/prisma/prisma.connection.provider";
 
 import {
+  CreateDigitalLibraryInput,
   digitalLibrary,
   DigitalLibraryFilterBy,
 } from "./digital-library.repository.type";
@@ -27,9 +28,16 @@ export default class DigitalLibraryRepository {
     });
   }
 
-  public async findDigitalLibraries(filter: DigitalLibraryFilterBy) {
+  public async findMany(filter: DigitalLibraryFilterBy) {
     return this.prisma.digitalLibrary.findMany({
       where: filter,
+      select: digitalLibrary.select,
+    });
+  }
+
+  public async create(data: CreateDigitalLibraryInput) {
+    return this.prisma.digitalLibrary.create({
+      data,
       select: digitalLibrary.select,
     });
   }

--- a/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
@@ -31,3 +31,8 @@ export type UpdateDigitalLibraryInput = {
   regex?: Array<string>;
   isVerified?: boolean;
 };
+
+export type UpdateDigitalLibrariesRankInput = Array<{
+  id: number;
+  rank: number;
+}>;

--- a/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
@@ -10,4 +10,11 @@ export const digitalLibrary =
       rank: true,
     },
   });
-export type DigitalLibrary = Prisma.ArticleGetPayload<typeof digitalLibrary>;
+export type DigitalLibrary = Prisma.DigitalLibraryGetPayload<
+  typeof digitalLibrary
+>;
+
+export type DigitalLibraryFilterBy = {
+  id?: number;
+  name?: string;
+};

--- a/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
@@ -25,3 +25,9 @@ export type CreateDigitalLibraryInput = {
   isVerified: boolean;
   rank: number;
 };
+
+export type UpdateDigitalLibraryInput = {
+  name?: string;
+  regex?: Array<string>;
+  isVerified?: boolean;
+};

--- a/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/digital-library.repository.type.ts
@@ -18,3 +18,10 @@ export type DigitalLibraryFilterBy = {
   id?: number;
   name?: string;
 };
+
+export type CreateDigitalLibraryInput = {
+  name: string;
+  regex: Array<string>;
+  isVerified: boolean;
+  rank: number;
+};

--- a/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
@@ -8,7 +8,10 @@ import {
 
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
 import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
-import { UpdateDigitalLibraryDto } from "./dto/update.digital-library.dto";
+import {
+  UpdateDigitalLibrariesRankDto,
+  UpdateDigitalLibraryDto,
+} from "./dto/update.digital-library.dto";
 import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @Injectable()
@@ -49,6 +52,16 @@ export class DigitalLibraryAdminService {
 
   public async deleteDigitalLibrary(id: number): Promise<void> {
     await this.digitalLibraryRepository.delete(id);
+  }
+
+  public async updateDigitalLibrariesRank(
+    dto: UpdateDigitalLibrariesRankDto
+  ): Promise<GetDigitalLibrariesResponse> {
+    await this.digitalLibraryRepository.updateRanks(dto);
+    const digitalLibraries = await this.digitalLibraryRepository.findAll();
+    return {
+      digitalLibraries: digitalLibraries.map(this.transformDigitalLibrary),
+    };
   }
 
   private transformDigitalLibrary(

--- a/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
@@ -7,6 +7,7 @@ import {
 } from "@recnet-api/database/repository/digital-library.repository.type";
 
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
+import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
 import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @Injectable()
@@ -20,11 +21,21 @@ export class DigitalLibraryAdminService {
     filter: DigitalLibraryFilterBy
   ): Promise<GetDigitalLibrariesResponse> {
     const digitalLibraries =
-      await this.digitalLibraryRepository.findDigitalLibraries(filter);
+      await this.digitalLibraryRepository.findMany(filter);
 
     return {
       digitalLibraries: digitalLibraries.map(this.transformDigitalLibrary),
     };
+  }
+
+  public async createDigitalLibrary(
+    dto: CreateDigitalLibraryDto
+  ): Promise<DigitalLibrary> {
+    const createAnnouncementInput = { ...dto };
+    const dbDigitalLibrary = await this.digitalLibraryRepository.create(
+      createAnnouncementInput
+    );
+    return this.transformDigitalLibrary(dbDigitalLibrary);
   }
 
   private transformDigitalLibrary(

--- a/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
@@ -8,6 +8,7 @@ import {
 
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
 import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
+import { UpdateDigitalLibraryDto } from "./dto/update.digital-library.dto";
 import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @Injectable()
@@ -31,11 +32,19 @@ export class DigitalLibraryAdminService {
   public async createDigitalLibrary(
     dto: CreateDigitalLibraryDto
   ): Promise<DigitalLibrary> {
-    const createAnnouncementInput = { ...dto };
-    const dbDigitalLibrary = await this.digitalLibraryRepository.create(
-      createAnnouncementInput
-    );
+    const dbDigitalLibrary = await this.digitalLibraryRepository.create(dto);
     return this.transformDigitalLibrary(dbDigitalLibrary);
+  }
+
+  public async updateDigitalLibrary(
+    id: number,
+    dto: UpdateDigitalLibraryDto
+  ): Promise<DigitalLibrary> {
+    const updatedDbDigitalLibrary = await this.digitalLibraryRepository.update(
+      id,
+      dto
+    );
+    return this.transformDigitalLibrary(updatedDbDigitalLibrary);
   }
 
   private transformDigitalLibrary(

--- a/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
@@ -47,6 +47,10 @@ export class DigitalLibraryAdminService {
     return this.transformDigitalLibrary(updatedDbDigitalLibrary);
   }
 
+  public async deleteDigitalLibrary(id: number): Promise<void> {
+    await this.digitalLibraryRepository.delete(id);
+  }
+
   private transformDigitalLibrary(
     digitalLibrary: DbDigitalLibrary
   ): DigitalLibrary {

--- a/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.admin.service.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import DigitalLibraryRepository from "@recnet-api/database/repository/digital-library.repository";
+import {
+  DigitalLibrary as DbDigitalLibrary,
+  DigitalLibraryFilterBy,
+} from "@recnet-api/database/repository/digital-library.repository.type";
+
+import { GetDigitalLibrariesResponse } from "./digital-library.response";
+import { DigitalLibrary } from "./entities/digital-library.entity";
+
+@Injectable()
+export class DigitalLibraryAdminService {
+  constructor(
+    @Inject(DigitalLibraryRepository)
+    private readonly digitalLibraryRepository: DigitalLibraryRepository
+  ) {}
+
+  public async getDigitalLibraries(
+    filter: DigitalLibraryFilterBy
+  ): Promise<GetDigitalLibrariesResponse> {
+    const digitalLibraries =
+      await this.digitalLibraryRepository.findDigitalLibraries(filter);
+
+    return {
+      digitalLibraries: digitalLibraries.map(this.transformDigitalLibrary),
+    };
+  }
+
+  private transformDigitalLibrary(
+    digitalLibrary: DbDigitalLibrary
+  ): DigitalLibrary {
+    return {
+      id: digitalLibrary.id,
+      name: digitalLibrary.name,
+      regex: digitalLibrary.regex,
+      rank: digitalLibrary.rank,
+      isVerified: digitalLibrary.isVerified,
+    };
+  }
+}

--- a/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
@@ -6,6 +6,9 @@ import {
   Query,
   Body,
   Post,
+  Patch,
+  ParseIntPipe,
+  Param,
 } from "@nestjs/common";
 import {
   ApiOkResponse,
@@ -23,6 +26,7 @@ import {
 
 import {
   getDigitalLibrariesParamsSchema,
+  patchDigitalLibrariesRequestSchema,
   postDigitalLibrariesRequestSchema,
 } from "@recnet/recnet-api-model";
 
@@ -30,6 +34,7 @@ import { DigitalLibraryAdminService } from "./digital-library.admin.service";
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
 import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
 import { QueryDigitalLibraryDto } from "./dto/query.digital-library.dto";
+import { UpdateDigitalLibraryDto } from "./dto/update.digital-library.dto";
 import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @ApiTags("digital-libraries")
@@ -70,5 +75,21 @@ export class DigitalLibraryController {
     @Body() dto: CreateDigitalLibraryDto
   ): Promise<DigitalLibrary> {
     return this.digitalLibraryAdminService.createDigitalLibrary(dto);
+  }
+
+  @ApiOperation({
+    summary: "Update Digital Library",
+    description: "Update digital library by id.",
+  })
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: DigitalLibrary })
+  @Patch("/:id")
+  @Auth({ allowedRoles: ["ADMIN"] })
+  @UsePipes(new ZodValidationBodyPipe(patchDigitalLibrariesRequestSchema))
+  public async updateAnnouncement(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: UpdateDigitalLibraryDto
+  ): Promise<DigitalLibrary> {
+    return this.digitalLibraryAdminService.updateDigitalLibrary(id, dto);
   }
 }

--- a/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
@@ -9,6 +9,7 @@ import {
   Patch,
   ParseIntPipe,
   Param,
+  Delete,
 } from "@nestjs/common";
 import {
   ApiOkResponse,
@@ -91,5 +92,18 @@ export class DigitalLibraryController {
     @Body() dto: UpdateDigitalLibraryDto
   ): Promise<DigitalLibrary> {
     return this.digitalLibraryAdminService.updateDigitalLibrary(id, dto);
+  }
+
+  @ApiOperation({
+    summary: "Delete Digital Library",
+    description: "Delete digital library by id.",
+  })
+  @ApiBearerAuth()
+  @Delete("/:id")
+  @Auth({ allowedRoles: ["ADMIN"] })
+  public async deleteDigitalLibrary(
+    @Param("id", ParseIntPipe) id: number
+  ): Promise<void> {
+    return this.digitalLibraryAdminService.deleteDigitalLibrary(id);
   }
 }

--- a/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, UseFilters, Get, UsePipes, Query } from "@nestjs/common";
+import {
+  Controller,
+  UseFilters,
+  Get,
+  UsePipes,
+  Query,
+  Body,
+  Post,
+} from "@nestjs/common";
 import {
   ApiOkResponse,
   ApiOperation,
@@ -8,13 +16,21 @@ import {
 
 import { Auth } from "@recnet-api/utils/auth/auth.decorator";
 import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
-import { ZodValidationQueryPipe } from "@recnet-api/utils/pipes/zod.validation.pipe";
+import {
+  ZodValidationBodyPipe,
+  ZodValidationQueryPipe,
+} from "@recnet-api/utils/pipes/zod.validation.pipe";
 
-import { getDigitalLibrariesParamsSchema } from "@recnet/recnet-api-model";
+import {
+  getDigitalLibrariesParamsSchema,
+  postDigitalLibrariesRequestSchema,
+} from "@recnet/recnet-api-model";
 
 import { DigitalLibraryAdminService } from "./digital-library.admin.service";
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
+import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
 import { QueryDigitalLibraryDto } from "./dto/query.digital-library.dto";
+import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @ApiTags("digital-libraries")
 @Controller("digital-libraries")
@@ -38,5 +54,21 @@ export class DigitalLibraryController {
     @Query() dto: QueryDigitalLibraryDto
   ): Promise<GetDigitalLibrariesResponse> {
     return this.digitalLibraryAdminService.getDigitalLibraries(dto);
+  }
+
+  @ApiOperation({
+    summary: "Create Digital Library",
+    description:
+      "Create digital library. After creating, need engineer to add related service in backend.",
+  })
+  @ApiOkResponse({ type: DigitalLibrary })
+  @ApiBearerAuth()
+  @Post()
+  @Auth({ allowedRoles: ["ADMIN"] })
+  @UsePipes(new ZodValidationBodyPipe(postDigitalLibrariesRequestSchema))
+  public async createDigitalLibrary(
+    @Body() dto: CreateDigitalLibraryDto
+  ): Promise<DigitalLibrary> {
+    return this.digitalLibraryAdminService.createDigitalLibrary(dto);
   }
 }

--- a/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, UseFilters, Get, UsePipes, Query } from "@nestjs/common";
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiBearerAuth,
+} from "@nestjs/swagger";
+
+import { Auth } from "@recnet-api/utils/auth/auth.decorator";
+import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
+import { ZodValidationQueryPipe } from "@recnet-api/utils/pipes/zod.validation.pipe";
+
+import { getDigitalLibrariesParamsSchema } from "@recnet/recnet-api-model";
+
+import { DigitalLibraryAdminService } from "./digital-library.admin.service";
+import { GetDigitalLibrariesResponse } from "./digital-library.response";
+import { QueryDigitalLibraryDto } from "./dto/query.digital-library.dto";
+
+@ApiTags("digital-libraries")
+@Controller("digital-libraries")
+@UseFilters(RecnetExceptionFilter)
+export class DigitalLibraryController {
+  constructor(
+    private readonly digitalLibraryAdminService: DigitalLibraryAdminService
+  ) {}
+
+  @ApiOperation({
+    summary: "Get Digital Library ",
+    description:
+      "Get digital library data. If query id and name is not provided, it will return all digital library data.",
+  })
+  @ApiOkResponse({ type: GetDigitalLibrariesResponse })
+  @ApiBearerAuth()
+  @Get()
+  @Auth({ allowedRoles: ["ADMIN"] })
+  @UsePipes(new ZodValidationQueryPipe(getDigitalLibrariesParamsSchema))
+  public async getDigitalLibraries(
+    @Query() dto: QueryDigitalLibraryDto
+  ): Promise<GetDigitalLibrariesResponse> {
+    return this.digitalLibraryAdminService.getDigitalLibraries(dto);
+  }
+}

--- a/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.controller.ts
@@ -28,6 +28,7 @@ import {
 import {
   getDigitalLibrariesParamsSchema,
   patchDigitalLibrariesRequestSchema,
+  postDigitalLibrariesRankRequestSchema,
   postDigitalLibrariesRequestSchema,
 } from "@recnet/recnet-api-model";
 
@@ -35,7 +36,10 @@ import { DigitalLibraryAdminService } from "./digital-library.admin.service";
 import { GetDigitalLibrariesResponse } from "./digital-library.response";
 import { CreateDigitalLibraryDto } from "./dto/create.digital-library.dto";
 import { QueryDigitalLibraryDto } from "./dto/query.digital-library.dto";
-import { UpdateDigitalLibraryDto } from "./dto/update.digital-library.dto";
+import {
+  UpdateDigitalLibrariesRankDto,
+  UpdateDigitalLibraryDto,
+} from "./dto/update.digital-library.dto";
 import { DigitalLibrary } from "./entities/digital-library.entity";
 
 @ApiTags("digital-libraries")
@@ -87,7 +91,7 @@ export class DigitalLibraryController {
   @Patch("/:id")
   @Auth({ allowedRoles: ["ADMIN"] })
   @UsePipes(new ZodValidationBodyPipe(patchDigitalLibrariesRequestSchema))
-  public async updateAnnouncement(
+  public async updateDigitalLibrary(
     @Param("id", ParseIntPipe) id: number,
     @Body() dto: UpdateDigitalLibraryDto
   ): Promise<DigitalLibrary> {
@@ -105,5 +109,20 @@ export class DigitalLibraryController {
     @Param("id", ParseIntPipe) id: number
   ): Promise<void> {
     return this.digitalLibraryAdminService.deleteDigitalLibrary(id);
+  }
+
+  @ApiOperation({
+    summary: "Update Digital Libraries Rank",
+    description: "Update digital libraries rank.",
+  })
+  @ApiBearerAuth()
+  @ApiOkResponse({ type: GetDigitalLibrariesResponse })
+  @Post("/rank")
+  @Auth({ allowedRoles: ["ADMIN"] })
+  @UsePipes(new ZodValidationBodyPipe(postDigitalLibrariesRankRequestSchema))
+  public async updateDigitalLibrariesRank(
+    @Body() dto: UpdateDigitalLibrariesRankDto
+  ): Promise<GetDigitalLibrariesResponse> {
+    return this.digitalLibraryAdminService.updateDigitalLibrariesRank(dto);
   }
 }

--- a/apps/recnet-api/src/modules/digital-library/digital-library.module.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.module.ts
@@ -4,11 +4,15 @@ import { REQUEST } from "@nestjs/core";
 import { DbRepositoryModule } from "@recnet-api/database/repository/db.repository.module";
 import DigitalLibraryRepository from "@recnet-api/database/repository/digital-library.repository";
 
+import { DigitalLibraryAdminService } from "./digital-library.admin.service";
 import { DIGITAL_LIBRARY } from "./digital-library.const";
+import { DigitalLibraryController } from "./digital-library.controller";
 import { DigitalLibraryServiceFactory } from "./digital-library.service";
 
 @Module({
+  controllers: [DigitalLibraryController],
   providers: [
+    DigitalLibraryAdminService,
     {
       provide: DIGITAL_LIBRARY,
       useFactory: DigitalLibraryServiceFactory,

--- a/apps/recnet-api/src/modules/digital-library/digital-library.response.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.response.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+import { DigitalLibrary } from "./entities/digital-library.entity";
+
+export class GetDigitalLibrariesResponse {
+  @ApiProperty()
+  digitalLibraries: Array<DigitalLibrary>;
+}

--- a/apps/recnet-api/src/modules/digital-library/dto/create.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/create.digital-library.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateDigitalLibraryDto {
+  @ApiProperty({
+    example: "arXiv",
+  })
+  name: string;
+
+  @ApiProperty({
+    example: ["https?://arxiv.org/(abs|pdf|html)/(?<id>[0-9.]+(v[0-9]+)?)"],
+  })
+  regex: Array<string>;
+
+  @ApiProperty({
+    description:
+      "The rank of the digital library. The smaller the rank, the higher the priority.",
+    example: 1,
+  })
+  rank: number;
+
+  @ApiProperty({
+    example: true,
+  })
+  isVerified: boolean;
+}

--- a/apps/recnet-api/src/modules/digital-library/dto/create.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/create.digital-library.dto.ts
@@ -13,8 +13,10 @@ export class CreateDigitalLibraryDto {
 
   @ApiProperty({
     description:
-      "The rank of the digital library. The smaller the rank, the higher the priority.",
+      "The rank of the digital library. The smaller the rank, the higher the priority. The rank must be between 1 and 100.",
     example: 1,
+    minimum: 1,
+    maximum: 100,
   })
   rank: number;
 

--- a/apps/recnet-api/src/modules/digital-library/dto/query.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/query.digital-library.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+
+export class QueryDigitalLibraryDto {
+  @ApiPropertyOptional({
+    description:
+      "The id of the digital library. If not specified, it will return all digital libraries.",
+  })
+  id?: number;
+
+  @ApiPropertyOptional({
+    description:
+      "The name of the digital library. If not specified, it will return all digital libraries.",
+  })
+  name?: string;
+}

--- a/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class UpdateDigitalLibraryDto {
+  @ApiProperty({
+    example: "arXiv",
+  })
+  name?: string;
+
+  @ApiProperty({
+    example: ["https?://arxiv.org/(abs|pdf|html)/(?<id>[0-9.]+(v[0-9]+)?)"],
+  })
+  regex?: Array<string>;
+
+  @ApiProperty({
+    example: true,
+  })
+  isVerified?: boolean;
+}

--- a/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
@@ -19,12 +19,17 @@ export class UpdateDigitalLibraryDto {
 
 export class UpdateRank {
   @ApiProperty({
+    description: "The ID of the digital library.",
     example: 1,
   })
   id: number;
 
   @ApiProperty({
+    description:
+      "The rank of the digital library. The smaller the rank, the higher the priority. The rank must be between 1 and 100.",
     example: 1,
+    minimum: 1,
+    maximum: 100,
   })
   rank: number;
 }

--- a/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
+++ b/apps/recnet-api/src/modules/digital-library/dto/update.digital-library.dto.ts
@@ -16,3 +16,17 @@ export class UpdateDigitalLibraryDto {
   })
   isVerified?: boolean;
 }
+
+export class UpdateRank {
+  @ApiProperty({
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 1,
+  })
+  rank: number;
+}
+
+export type UpdateDigitalLibrariesRankDto = Array<UpdateRank>;

--- a/apps/recnet-api/src/modules/digital-library/entities/digital-library.entity.ts
+++ b/apps/recnet-api/src/modules/digital-library/entities/digital-library.entity.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class DigitalLibrary {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  regex: Array<string>;
+
+  @ApiProperty()
+  rank: number;
+
+  @ApiProperty()
+  isVerified: boolean;
+}

--- a/apps/recnet-api/src/utils/error/recnet.error.const.ts
+++ b/apps/recnet-api/src/utils/error/recnet.error.const.ts
@@ -8,6 +8,7 @@ export const ErrorCode = {
   HANDLE_EXISTS: 1006,
   START_DATE_AFTER_END_DATE: 1007,
   ACCOUNT_NOT_ACTIVATED: 1008,
+  DIGITAL_LIBRARY_RANK_CONFLICT: 1009,
 
   // DB error codes
   DB_UNKNOWN_ERROR: 2000,
@@ -31,6 +32,8 @@ export const errorMessages = {
   [ErrorCode.HANDLE_EXISTS]: "Handle already exists",
   [ErrorCode.START_DATE_AFTER_END_DATE]: "Start date is after end date",
   [ErrorCode.ACCOUNT_NOT_ACTIVATED]: "The user account is not activated",
+  [ErrorCode.DIGITAL_LIBRARY_RANK_CONFLICT]:
+    "Digital library rank must be unique",
   [ErrorCode.DB_UNKNOWN_ERROR]: "Database error",
   [ErrorCode.DB_USER_NOT_FOUND]: "User not found",
   [ErrorCode.DB_UNIQUE_CONSTRAINT]: "Unique constraint violation",

--- a/apps/recnet/src/app/reactivate/ReactivateButton.tsx
+++ b/apps/recnet/src/app/reactivate/ReactivateButton.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { Button } from "@radix-ui/themes";
-import { trpc } from "@recnet/recnet-web/app/_trpc/client";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@recnet/recnet-web/app/AuthContext";
 import { useState } from "react";
 import { toast } from "sonner";
+
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
+import { trpc } from "@recnet/recnet-web/app/_trpc/client";
 
 export function ReactivateButton() {
   const [isLoading, setIsLoading] = useState(false);

--- a/apps/recnet/src/app/reactivate/page.tsx
+++ b/apps/recnet/src/app/reactivate/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { Avatar } from "@recnet/recnet-web/components/Avatar";
 import { cn } from "@recnet/recnet-web/utils/cn";
 import { getUserServerSide } from "@recnet/recnet-web/utils/getUserServerSide";
+
 import { ReactivateButton } from "./ReactivateButton";
 
 export default async function ReactivatePage() {

--- a/libs/recnet-api-model/src/index.ts
+++ b/libs/recnet-api-model/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/api/announcement";
 export * from "./lib/api/article";
+export * from "./lib/api/digital-library";
 export * from "./lib/api/invite-code";
 export * from "./lib/api/rec";
 export * from "./lib/api/stat";

--- a/libs/recnet-api-model/src/lib/api/digital-library.ts
+++ b/libs/recnet-api-model/src/lib/api/digital-library.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+import { digitalLibrarySchema } from "../model";
+
+// GET /digital-libraries
+export const getDigitalLibrariesParamsSchema = z.object({
+  id: z.coerce.number().optional(),
+  name: z.string().optional(),
+});
+export type GetDigitalLibrariesParams = z.infer<
+  typeof getDigitalLibrariesParamsSchema
+>;
+
+export const getDigitalLibrariesResponseSchema = z.object({
+  digitalLibraries: z.array(digitalLibrarySchema),
+});
+export type GetDigitalLibrariesResponse = z.infer<
+  typeof getDigitalLibrariesResponseSchema
+>;
+
+// POST /digital-libraries
+export const postDigitalLibrariesRequestSchema = digitalLibrarySchema.omit({
+  id: true,
+});
+export type postDigitalLibrariesRequestSchema = z.infer<
+  typeof postDigitalLibrariesRequestSchema
+>;
+
+export const postDigitalLibrariesResponseSchema = digitalLibrarySchema;
+export type PostDigitalLibrariesResponse = z.infer<
+  typeof postDigitalLibrariesResponseSchema
+>;
+
+// PATCH /digital-libraries/:id
+export const patchDigitalLibrariesRequestSchema = digitalLibrarySchema
+  .omit({
+    id: true,
+    rank: true,
+  })
+  .partial();
+export type PatchDigitalLibrariesRequest = z.infer<
+  typeof patchDigitalLibrariesRequestSchema
+>;
+
+export const patchDigitalLibrariesResponseSchema = digitalLibrarySchema;
+
+// POST /digital-libraries/rank
+export const postDigitalLibrariesRankRequestSchema = z.array(
+  z.object({
+    id: z.number(),
+    rank: z.number(),
+  })
+);
+export type PostDigitalLibrariesRankRequest = z.infer<
+  typeof postDigitalLibrariesRankRequestSchema
+>;

--- a/libs/recnet-api-model/src/lib/api/digital-library.ts
+++ b/libs/recnet-api-model/src/lib/api/digital-library.ts
@@ -48,7 +48,7 @@ export const patchDigitalLibrariesResponseSchema = digitalLibrarySchema;
 export const postDigitalLibrariesRankRequestSchema = z.array(
   z.object({
     id: z.number(),
-    rank: z.number(),
+    rank: z.number().min(1).max(100),
   })
 );
 export type PostDigitalLibrariesRankRequest = z.infer<

--- a/libs/recnet-api-model/src/lib/api/digital-library.ts
+++ b/libs/recnet-api-model/src/lib/api/digital-library.ts
@@ -22,7 +22,7 @@ export type GetDigitalLibrariesResponse = z.infer<
 export const postDigitalLibrariesRequestSchema = digitalLibrarySchema.omit({
   id: true,
 });
-export type postDigitalLibrariesRequestSchema = z.infer<
+export type PostDigitalLibrariesRequest = z.infer<
   typeof postDigitalLibrariesRequestSchema
 >;
 

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -72,3 +72,12 @@ export const announcementSchema = z.object({
   createdBy: userPreviewSchema,
 });
 export type Announcement = z.infer<typeof announcementSchema>;
+
+export const digitalLibrarySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  regex: z.array(z.string()),
+  rank: z.number(),
+  isVerified: z.boolean(),
+});
+export type DigitalLibrary = z.infer<typeof digitalLibrarySchema>;

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -77,7 +77,7 @@ export const digitalLibrarySchema = z.object({
   id: z.number(),
   name: z.string(),
   regex: z.array(z.string()),
-  rank: z.number(),
+  rank: z.number().min(1).max(100),
   isVerified: z.boolean(),
 });
 export type DigitalLibrary = z.infer<typeof digitalLibrarySchema>;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Create API for admin to conduct CRUD for `Digital Library`.

Add the following APIs:

- `GET /digital-libraries`
- `POST /digital-libraries`
- `PATCH /digital-libraries/:id`
- `DELETE /digital-libraries/:id`
- `POST /digital-libraries/rank`

Design Doc: [Notion](https://www.notion.so/e5979d5d153b4df89ccd622c488dbbd3?v=ea2512f452514fad9f1331fab3923738&p=26e1673576a84541bb4d789fea2ff518&pm=s)

## Related Issue

- https://github.com/lil-lab/recnet/issues/254

## Notes

N/A

## TODO

- [ ] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
