### PR TITLE
[recnet-web] Fix: Use unified link in rec form

### DIFF
--- a/apps/recnet/src/components/rec/NewArticleForm.tsx
+++ b/apps/recnet/src/components/rec/NewArticleForm.tsx
@@ -312,6 +312,7 @@ export function NewArticleForm(props: {
                   const foundArticle = data?.article;
                   if (foundArticle) {
                     // prefill if article is found
+                    setValue("link", foundArticle.link);
                     setValue("articleId", foundArticle.id);
                     setValue("doi", foundArticle.doi || undefined);
                     setValue("title", foundArticle.title);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
When creating new rec, if article is returned by our API (found by arxiv API), we use the "unified link" instead of the original link provided by user. Thus, if user provide a pdf arxiv link, we will overwrite by a arxiv abs link.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #298 

## Notes

<!-- Other thing to say -->

## Test

Try to use the any arxiv pdf link when creating new rec, you should see it's replaced by an abs arxiv link.

## TODO

- [ ] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
