### PR TITLE
[recnet-web] Display cycle in feeds page & consolidate date picker component

### DIFF
--- a/apps/recnet/src/app/admin/announcement/inapp/AnnouncementForm.tsx
+++ b/apps/recnet/src/app/admin/announcement/inapp/AnnouncementForm.tsx
@@ -177,6 +177,7 @@ export function AnnouncementForm(props: AnnouncementFormProps) {
                 render={({ field }) => (
                   <Flex gap="2" className="items-center text-gray-12 w-full">
                     <DatePicker
+                      mode="datetime"
                       value={field.value}
                       onChange={(date) => {
                         field.onChange(date);
@@ -212,6 +213,7 @@ export function AnnouncementForm(props: AnnouncementFormProps) {
                 render={({ field }) => (
                   <Flex gap="2" className="items-center text-gray-12 w-full">
                     <DatePicker
+                      mode="datetime"
                       value={field.value}
                       onChange={(date) => {
                         field.onChange(date);

--- a/apps/recnet/src/app/feeds/CutoffDatePicker.tsx
+++ b/apps/recnet/src/app/feeds/CutoffDatePicker.tsx
@@ -81,6 +81,10 @@ export function CutoffDatePicker(props: CutoffDatePickerProps) {
               More
             </Button>
           )}
+          popoverContentProps={{
+            side: "right",
+            alignOffset: -50,
+          }}
         />
       </div>
     </div>

--- a/apps/recnet/src/app/feeds/CutoffDatePicker.tsx
+++ b/apps/recnet/src/app/feeds/CutoffDatePicker.tsx
@@ -1,79 +1,48 @@
 "use client";
 
-// TODO: refactor this component to use the new DatePicker component
-import { useCalendar } from "@h6s/calendar";
-import { Button, Popover, Flex, Grid, Text } from "@radix-ui/themes";
-import { AnimatePresence, motion } from "framer-motion";
-import { useState } from "react";
+import { Button, Text } from "@radix-ui/themes";
+import { useRouter } from "next/navigation";
 
+import { DatePicker } from "@recnet/recnet-web/components/DatePicker";
 import { RecNetLink } from "@recnet/recnet-web/components/Link";
-import { cn } from "@recnet/recnet-web/utils/cn";
 
 import {
   formatDate,
-  getCutOffFromStartDate,
-  monthValMap,
   START_DATE,
-  WeekTs,
+  getCutOffFromStartDate,
 } from "@recnet/recnet-date-fns";
 
 const MAX_CUTOFFS_DISPLAY = 5;
 
-function getWeekDay(date: Date) {
-  return Intl.DateTimeFormat("default", {
-    weekday: "short",
-  }).format(date);
-}
-
 function getFeedPageLink(date: Date) {
   return `/feeds?date=${formatDate(date)}`;
-}
-
-function clampSelectedYearMonth(_date: Date, min: Date, max: Date) {
-  return new Date(
-    Math.min(Math.max(_date.getTime(), min.getTime()), max.getTime())
-  );
 }
 
 interface CutoffDatePickerProps {
   currentSelectedCutoff: Date;
 }
 
-type View = "default" | "month" | "year";
-
 export function CutoffDatePicker(props: CutoffDatePickerProps) {
   const { currentSelectedCutoff } = props;
-  const [isOpen, setIsOpen] = useState(false);
-  const [view, setView] = useState<View>("default");
+  const now = new Date();
+  const router = useRouter();
+
+  const shouldDisable = (d: Date) => {
+    // outside of START_DATE and now
+    if (d > now || d < START_DATE) {
+      return true;
+    }
+    if (d.getDay() !== 2) {
+      return true;
+    }
+    return false;
+  };
+  const onDateChange = (date: Date) => {
+    const link = getFeedPageLink(date);
+    router.push(link);
+  };
 
   const cutoffs = getCutOffFromStartDate();
-  const {
-    headers,
-    body,
-    month: currentSelectedMonth,
-    year: currentSelectedYear,
-    navigation,
-  } = useCalendar();
-  const now = new Date();
-  const firstDayOfNextMonth = new Date(
-    currentSelectedYear,
-    currentSelectedMonth + 1,
-    1
-  );
-  const firstDayOfPrevMonth = new Date(
-    currentSelectedYear,
-    currentSelectedMonth,
-    1
-  );
-
-  const tableCellBaseClass = "font-[12px] text-gray-9 px-1";
-
-  // get years from START_DATE to now
-  const startYear = new Date(START_DATE).getFullYear();
-  const years = [];
-  for (let i = startYear; i <= now.getFullYear(); i++) {
-    years.push(i);
-  }
 
   return (
     <div className="w-full flex flex-col gap-y-1">
@@ -81,9 +50,6 @@ export function CutoffDatePicker(props: CutoffDatePickerProps) {
         size="1"
         weight={"medium"}
         className="text-gray-11 cursor-pointer hover:bg-gray-3 hover:text-gray-12 transition-all ease-in-out rounded-2 p-2 select-none"
-        onPointerDown={() => {
-          setIsOpen(true);
-        }}
       >
         Previous cycles
       </Text>
@@ -106,260 +72,16 @@ export function CutoffDatePicker(props: CutoffDatePickerProps) {
             </RecNetLink>
           );
         })}
-        <Popover.Root
-          open={isOpen}
-          onOpenChange={(open) => {
-            setIsOpen(open);
-            // reset view on open and reset to today
-            if (open) {
-              navigation.setToday();
-              setView("default");
-            }
-          }}
-        >
-          <Popover.Trigger>
+        <DatePicker
+          value={currentSelectedCutoff}
+          onChange={onDateChange}
+          shouldDisable={shouldDisable}
+          renderTrigger={() => (
             <Button variant="ghost" className="w-fit cursor-pointer" size="1">
               More
             </Button>
-          </Popover.Trigger>
-          <Popover.Content
-            className="overflow-hidden"
-            side="right"
-            alignOffset={-50}
-          >
-            <Flex className="justify-center items-center w-full p-2 mb-2">
-              <Button
-                variant="ghost"
-                className="mr-auto cursor-pointer"
-                disabled={firstDayOfPrevMonth < START_DATE}
-                onClick={() => {
-                  navigation.toPrev();
-                }}
-              >
-                Previous
-              </Button>
-              <div className="font-medium text-gray-10 flex">
-                <Button
-                  variant="ghost"
-                  size="3"
-                  className="m-0 p-2 cursor-pointer"
-                  onClick={() => {
-                    if (view === "year") {
-                      setView("default");
-                    } else {
-                      setView("year");
-                    }
-                  }}
-                >
-                  {currentSelectedYear}
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="3"
-                  className="m-0 p-2 cursor-pointer"
-                  onClick={() => {
-                    if (view === "month") {
-                      setView("default");
-                    } else {
-                      setView("month");
-                    }
-                  }}
-                >
-                  {(currentSelectedMonth + 1).toString().padStart(2, "0")}
-                </Button>
-              </div>
-              <Button
-                variant="ghost"
-                className=" ml-auto cursor-pointer"
-                disabled={firstDayOfNextMonth > now}
-                onClick={() => {
-                  navigation.toNext();
-                }}
-              >
-                Next
-              </Button>
-            </Flex>
-            <AnimatePresence initial={false} mode="sync">
-              <motion.div
-                initial={{ height: 0 }}
-                animate={{ height: "auto" }}
-                exit={{ height: 0 }}
-                transition={{ duration: 0.15, delay: 0.15 }}
-                key={view}
-              >
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15, delay: 0.15 }}
-                  key={view + "-content"}
-                >
-                  {view === "default" ? (
-                    <table className="table-fixed border-separate border-spacing-2">
-                      <thead>
-                        <tr>
-                          {headers.weekDays.map(({ key, value }) => {
-                            return (
-                              <th
-                                key={key}
-                                className="font-[12px] text-gray-10 w-[40px] text-start"
-                              >
-                                {getWeekDay(value)}
-                              </th>
-                            );
-                          })}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {body.value.map(({ key, value: days }) => {
-                          return (
-                            <tr key={key}>
-                              {days.map(({ key: dayKey, value }) => {
-                                const tableCellWeekDay = value.getDay();
-                                const tableCellMonth = value.getMonth();
-                                value.setUTCHours(23, 59, 59, 999);
-                                if (
-                                  tableCellMonth !== currentSelectedMonth ||
-                                  value > now ||
-                                  value < START_DATE
-                                ) {
-                                  return (
-                                    <td
-                                      key={dayKey}
-                                      className={cn(
-                                        tableCellBaseClass,
-                                        "cursor-not-allowed text-gray-6"
-                                      )}
-                                    >
-                                      {value.getDate()}
-                                    </td>
-                                  );
-                                }
-                                if (tableCellWeekDay !== 2) {
-                                  return (
-                                    <td
-                                      key={dayKey}
-                                      className={cn(
-                                        "cursor-not-allowed",
-                                        tableCellBaseClass
-                                      )}
-                                    >
-                                      {value.getDate()}
-                                    </td>
-                                  );
-                                }
-                                return (
-                                  <td
-                                    key={dayKey}
-                                    className={cn(tableCellBaseClass)}
-                                  >
-                                    <RecNetLink
-                                      href={getFeedPageLink(value)}
-                                      radixLinkProps={{
-                                        className: cn({
-                                          "font-bold":
-                                            formatDate(
-                                              currentSelectedCutoff
-                                            ) === formatDate(value),
-                                        }),
-                                        onClick: () => {
-                                          setIsOpen(false);
-                                        },
-                                      }}
-                                    >
-                                      {value.getDate()}
-                                    </RecNetLink>
-                                  </td>
-                                );
-                              })}
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  ) : view === "month" ? (
-                    <Grid columns={"4"} gap={"2"} className="w-[344px]">
-                      {Object.entries(monthValMap).map(([key, value]) => {
-                        // disable if that month is before START_DATE or after now
-                        const anchorDate = new Date(
-                          currentSelectedYear,
-                          value,
-                          1
-                        );
-                        const shouldDisabled =
-                          anchorDate.getTime() <
-                            START_DATE.getTime() - WeekTs * 4 ||
-                          anchorDate.getTime() > now.getTime();
-                        return (
-                          <Button
-                            variant="ghost"
-                            key={key}
-                            className={cn(
-                              "group cursor-pointer border-[1px] border-solid border-gray-6 p-1 m-0",
-                              {
-                                "cursor-not-allowed text-gray-6":
-                                  shouldDisabled,
-                              }
-                            )}
-                            onClick={() => {
-                              navigation.setDate(
-                                clampSelectedYearMonth(
-                                  anchorDate,
-                                  START_DATE,
-                                  now
-                                )
-                              );
-                              setView("default");
-                            }}
-                            disabled={shouldDisabled}
-                          >
-                            <p
-                              className={cn(
-                                "text-gray-11 group-hover:text-gray-12 transition-all ease-in-out",
-                                {
-                                  "text-gray-6 group-hover:text-gray-6":
-                                    shouldDisabled,
-                                }
-                              )}
-                            >
-                              {key}
-                            </p>
-                          </Button>
-                        );
-                      })}
-                    </Grid>
-                  ) : (
-                    <Grid columns={"4"} gap={"2"} className="w-[344px]">
-                      {years.map((year) => {
-                        return (
-                          <Button
-                            variant="ghost"
-                            key={year}
-                            className="group cursor-pointer border-[1px] border-solid border-gray-6 p-1 m-0"
-                            onClick={() => {
-                              navigation.setDate(
-                                clampSelectedYearMonth(
-                                  new Date(year, currentSelectedMonth, 1),
-                                  START_DATE,
-                                  now
-                                )
-                              );
-                              setView("default");
-                            }}
-                          >
-                            <p className="text-gray-11 group-hover:text-gray-12 transition-all ease-in-out">
-                              {year}
-                            </p>
-                          </Button>
-                        );
-                      })}
-                    </Grid>
-                  )}
-                </motion.div>
-              </motion.div>
-            </AnimatePresence>
-          </Popover.Content>
-        </Popover.Root>
+          )}
+        />
       </div>
     </div>
   );

--- a/apps/recnet/src/app/feeds/page.tsx
+++ b/apps/recnet/src/app/feeds/page.tsx
@@ -17,6 +17,7 @@ import {
   getCutOff,
   getLatestCutOff,
   START_DATE,
+  formatDate,
 } from "@recnet/recnet-date-fns";
 
 import { GetRecsFeedsResponse, Rec } from "@recnet/recnet-api-model";
@@ -139,22 +140,29 @@ export default function FeedPage({
     >
       <OnboardingDialog />
       {Object.keys(recsGroupByTitle).length > 0 ? (
-        <InfiniteScroll
-          dataLength={Object.keys(recsGroupByTitle).length}
-          next={fetchNextPage}
-          hasMore={hasNextPage}
-          loader={<RecCardSkeleton />}
-          className="flex flex-col gap-y-4"
-        >
-          {Object.keys(recsGroupByTitle).map((recTitle, idx) => {
-            const recs = recsGroupByTitle[recTitle];
-            return <RecCard key={`${recTitle}-${idx}`} recs={recs} />;
-          })}
-        </InfiniteScroll>
+        <>
+          <div className="w-full mb-2 hidden md:flex flex-row justify-start">
+            <Text size="1" className="text-gray-10">
+              Current cycle: {formatDate(cutoff)}
+            </Text>
+          </div>
+          <InfiniteScroll
+            dataLength={Object.keys(recsGroupByTitle).length}
+            next={fetchNextPage}
+            hasMore={hasNextPage}
+            loader={<RecCardSkeleton />}
+            className="flex flex-col gap-y-4"
+          >
+            {Object.keys(recsGroupByTitle).map((recTitle, idx) => {
+              const recs = recsGroupByTitle[recTitle];
+              return <RecCard key={`${recTitle}-${idx}`} recs={recs} />;
+            })}
+          </InfiniteScroll>
+        </>
       ) : (
         <div className="h-[150px] w-full flex justify-center items-center">
           <Text size="3" className="text-gray-10">
-            No recommendations from your network this week.
+            No recommendations from your network on {formatDate(cutoff)}.
           </Text>
         </div>
       )}

--- a/apps/recnet/src/app/help/page.tsx
+++ b/apps/recnet/src/app/help/page.tsx
@@ -39,7 +39,12 @@ const faqs: {
     title: "Cycle",
     content: () => {
       const nextCutOff = getNextCutOff();
-      return `The cutoff time of each cycle is 11:59:59 PM GMT on each Tuesday. The next cutoff in your local time: ${getVerboseDateString(nextCutOff)}.`;
+      return `The cutoff time of each cycle is 11:59:59 PM GMT on each Tuesday. The next cutoff in your local time: ${getVerboseDateString(
+        nextCutOff,
+        {
+          hourCycle: "h11",
+        }
+      )}.`;
     },
   },
 ];

--- a/apps/recnet/src/components/DatePicker.tsx
+++ b/apps/recnet/src/components/DatePicker.tsx
@@ -152,11 +152,11 @@ export function DatePicker(props: DatePickerProps) {
 
   const tableCellBaseClass = "font-[12px] text-gray-9 px-1";
 
-  // get years from START_DATE to cuurent year + 10
+  // get years from START_DATE to current year +- 10
   const now = new Date();
   const startYear = new Date(START_DATE).getFullYear();
   const years: number[] = [];
-  for (let i = startYear; i <= now.getFullYear() + 10; i++) {
+  for (let i = startYear - 10; i <= now.getFullYear() + 10; i++) {
     years.push(i);
   }
 
@@ -180,6 +180,7 @@ export function DatePicker(props: DatePickerProps) {
       <Popover.Content
         className="overflow-hidden"
         maxWidth={"376px"}
+        minWidth={"376px"}
         side="bottom"
       >
         {selectedDate ? (
@@ -316,6 +317,7 @@ export function DatePicker(props: DatePickerProps) {
                                         "transition-all ease-in-out"
                                       )}
                                       onClick={() => {
+                                        console.log("date: ", v);
                                         setSelectedDate(v);
                                       }}
                                     >

--- a/apps/recnet/src/components/DatePicker.tsx
+++ b/apps/recnet/src/components/DatePicker.tsx
@@ -125,6 +125,7 @@ interface DatePickerProps {
   value: Date;
   onChange: (date: Date) => void;
   renderTrigger: (val?: Date) => React.ReactNode;
+  mode?: "date" | "datetime";
 }
 
 /**
@@ -134,10 +135,11 @@ interface DatePickerProps {
  * @param props.value The current value of the date picker.
  * @param props.onChange The function to call when the date picker value changes.
  * @param props.renderTrigger The function to render the trigger component.
+ * @param props.mode The mode of the date picker. Can be either "date" or "datetime". "datetime" allows the user to select the time as well.
  */
 
 export function DatePicker(props: DatePickerProps) {
-  const { value, onChange, renderTrigger } = props;
+  const { value, onChange, renderTrigger, mode = "date" } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [view, setView] = useState<View>("default");
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -317,8 +319,13 @@ export function DatePicker(props: DatePickerProps) {
                                         "transition-all ease-in-out"
                                       )}
                                       onClick={() => {
-                                        console.log("date: ", v);
-                                        setSelectedDate(v);
+                                        // if mode is "datetime", proceed to time selector
+                                        if (mode === "datetime") {
+                                          setSelectedDate(v);
+                                          return;
+                                        }
+                                        onChange(v);
+                                        setIsOpen(false);
                                       }}
                                     >
                                       <div

--- a/apps/recnet/src/components/DatePicker.tsx
+++ b/apps/recnet/src/components/DatePicker.tsx
@@ -126,6 +126,7 @@ interface DatePickerProps {
   onChange: (date: Date) => void;
   renderTrigger: (val?: Date) => React.ReactNode;
   mode?: "date" | "datetime";
+  shouldDisable?: (date: Date) => boolean;
 }
 
 /**
@@ -136,10 +137,17 @@ interface DatePickerProps {
  * @param props.onChange The function to call when the date picker value changes.
  * @param props.renderTrigger The function to render the trigger component.
  * @param props.mode The mode of the date picker. Can be either "date" or "datetime". "datetime" allows the user to select the time as well.
+ * @param props.disableRule The function to determine if a date should be disabled. Return true to disable the date.
  */
 
 export function DatePicker(props: DatePickerProps) {
-  const { value, onChange, renderTrigger, mode = "date" } = props;
+  const {
+    value,
+    onChange,
+    renderTrigger,
+    mode = "date",
+    shouldDisable = () => false,
+  } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [view, setView] = useState<View>("default");
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -308,17 +316,37 @@ export function DatePicker(props: DatePickerProps) {
                                           isSelected ? "after:bg-blue-4" : null
                                         );
 
+                                  const isNotThisMonth =
+                                    v.getMonth() !== currentSelectedMonth;
+                                  if (isNotThisMonth) {
+                                    return (
+                                      <td
+                                        key={dayKey}
+                                        className={cn(
+                                          tableCellBaseClass,
+                                          "cursor-not-allowed text-gray-6"
+                                        )}
+                                      >
+                                        <div className="flex flex-row justify-center">
+                                          {v.getDate()}
+                                        </div>
+                                      </td>
+                                    );
+                                  }
+
+                                  const isDisabled = shouldDisable(v);
                                   return (
                                     <td
                                       key={dayKey}
                                       className={cn(
                                         tableCellBaseClass,
-                                        "cursor-pointer",
-                                        "text-gray-11",
-                                        "hover:text-blue-10",
+                                        !isDisabled
+                                          ? "cursor-pointer text-gray-11 hover:text-blue-10"
+                                          : "cursor-not-allowed",
                                         "transition-all ease-in-out"
                                       )}
                                       onClick={() => {
+                                        if (isDisabled) return;
                                         // if mode is "datetime", proceed to time selector
                                         if (mode === "datetime") {
                                           setSelectedDate(v);

--- a/apps/recnet/src/components/DatePicker.tsx
+++ b/apps/recnet/src/components/DatePicker.tsx
@@ -127,6 +127,7 @@ interface DatePickerProps {
   renderTrigger: (val?: Date) => React.ReactNode;
   mode?: "date" | "datetime";
   shouldDisable?: (date: Date) => boolean;
+  popoverContentProps?: React.ComponentProps<typeof Popover.Content>;
 }
 
 /**
@@ -147,6 +148,7 @@ export function DatePicker(props: DatePickerProps) {
     renderTrigger,
     mode = "date",
     shouldDisable = () => false,
+    popoverContentProps = {},
   } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [view, setView] = useState<View>("default");
@@ -192,6 +194,7 @@ export function DatePicker(props: DatePickerProps) {
         maxWidth={"376px"}
         minWidth={"376px"}
         side="bottom"
+        {...popoverContentProps}
       >
         {selectedDate ? (
           <div className="flex flex-col p-2">

--- a/libs/recnet-date-fns/src/lib/recnet-date-fns.ts
+++ b/libs/recnet-date-fns/src/lib/recnet-date-fns.ts
@@ -85,22 +85,26 @@ export const getVerboseDateString = (
   }
 ): string => {
   const { withTime = true, ...restOptions } = options || {};
-  const localTime = date.toLocaleTimeString();
-  return (
-    Intl.DateTimeFormat("default", {
-      weekday: "long",
-      month: "numeric",
-      day: "numeric",
-      // hour: "2-digit",
-      // minute: "2-digit",
-      // second: "2-digit",
-      // timeZoneName: "short",
-      // hourCycle: "h11",
-      ...restOptions,
-    })
-      .format(date)
-      .replaceAll(",", " ") + (withTime ? ` ${localTime}` : "")
-  );
+
+  const dateTimeFormatTimeOptions: Intl.DateTimeFormatOptions = withTime
+    ? {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        // timeZoneName: "short",
+        hourCycle: "h23",
+      }
+    : {};
+
+  return Intl.DateTimeFormat("default", {
+    weekday: "long",
+    month: "numeric",
+    day: "numeric",
+    ...dateTimeFormatTimeOptions,
+    ...restOptions,
+  })
+    .format(date)
+    .replaceAll(",", " ");
 };
 
 export const formatDate = (date: Date): string => {

--- a/libs/recnet-date-fns/src/lib/recnet-date-fns.ts
+++ b/libs/recnet-date-fns/src/lib/recnet-date-fns.ts
@@ -91,7 +91,6 @@ export const getVerboseDateString = (
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit",
-        // timeZoneName: "short",
         hourCycle: "h23",
       }
     : {};


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR mainly address two issues
1. Duplicate code in `CutoffDatePicker` and in `DatePicker`. This PR refactor the code duplication in `CutoffDatePicker` and extend `DatePicker` functionality.
2. Currently, the `/feeds` page doesn't show the current cycle. When navigating to old cycles, it's hard to know which cycle we are viewing currently.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #253 

## Notes

<!-- Other thing to say -->

## Test

The CutoffDatePicker should behave the same as in the past.
- Can only select Tuesday.

![Screenshot 2024-10-04 at 3 31 41 PM](https://github.com/user-attachments/assets/c58aea10-444f-447e-b01c-eb50640c4876)

We could see a "current cycle" indicator in feeds page like this
![Screenshot 2024-10-04 at 3 32 45 PM](https://github.com/user-attachments/assets/8cae929d-ae9a-45ca-9fc2-210c60e293fd)

## TODO

- [x] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [x] Version bump in `package.json` if needed
