### PR TITLE
chore: update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,9 +13,15 @@
 
 <!-- Other thing to say -->
 
+## Test
+
+<!--- Please describe in detail how you tested your changes locally. -->
+
+## Screenshots (if appropriate):
+
+<!--- Add screenshots of your changes here -->
+
 ## TODO
 
-- [ ] Paste the testing link
 - [ ] Clear `console.log` or `console.error` for debug usage
 - [ ] Update the documentation `recnet-docs` if needed
-- [ ] Version bump in `package.json` if needed


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
With the new github action and workflow, we can delete some TODOs in PR templates.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->

## TODO

- [ ] Paste the testing link
- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
- [ ] Version bump in `package.json` if needed
