### PR TITLE
[recnet-api] add rec reaction to get rec api

### DIFF
--- a/apps/recnet-api/src/database/repository/rec.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/rec.repository.type.ts
@@ -3,6 +3,16 @@ import { Prisma } from "@prisma/client";
 import { article } from "./article.repository.type";
 import { userPreview } from "./user.repository.type";
 
+export const recReaction = Prisma.validator<Prisma.RecReactionDefaultArgs>()({
+  select: {
+    id: true,
+    userId: true,
+    recId: true,
+    reaction: true,
+  },
+});
+export type RecReaction = Prisma.RecReactionGetPayload<typeof recReaction>;
+
 export const rec = Prisma.validator<Prisma.RecommendationDefaultArgs>()({
   select: {
     id: true,
@@ -15,19 +25,12 @@ export const rec = Prisma.validator<Prisma.RecommendationDefaultArgs>()({
     article: {
       select: article.select,
     },
+    reactions: {
+      select: recReaction.select,
+    },
   },
 });
 export type Rec = Prisma.RecommendationGetPayload<typeof rec>;
-
-export const recReaction = Prisma.validator<Prisma.RecReactionDefaultArgs>()({
-  select: {
-    id: true,
-    userId: true,
-    recId: true,
-    reaction: true,
-  },
-});
-export type RecReaction = Prisma.RecReactionGetPayload<typeof recReaction>;
 
 export type DateRange = {
   from?: Date;

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -162,6 +162,10 @@ export class EmailService {
       ...dbRec,
       cutoff: dbRec.cutoff.toISOString(),
       user: transformUserPreview(dbRec.user),
+      reactions: {
+        selfReactions: [],
+        numReactions: [],
+      },
     };
   }
 }

--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -7,14 +7,12 @@ import groupBy from "lodash.groupby";
 
 import { AppConfig, NodemailerConfig } from "@recnet-api/config/common.config";
 import RecRepository from "@recnet-api/database/repository/rec.repository";
-import {
-  Rec as DbRec,
-  RecFilterBy,
-} from "@recnet-api/database/repository/rec.repository.type";
+import { RecFilterBy } from "@recnet-api/database/repository/rec.repository.type";
 import UserRepository from "@recnet-api/database/repository/user.repository";
 import { User as DbUser } from "@recnet-api/database/repository/user.repository.type";
 import WeeklyDigestCronLogRepository from "@recnet-api/database/repository/weekly-digest-cron-log.repository";
 import { Rec } from "@recnet-api/modules/rec/entities/rec.entity";
+import { transformRec } from "@recnet-api/modules/rec/rec.transformer";
 import { sleep } from "@recnet-api/utils";
 
 import { getLatestCutOff } from "@recnet/recnet-date-fns";
@@ -27,8 +25,6 @@ import {
 } from "./email.const";
 import { SendMailResult, Transporter } from "./email.type";
 import WeeklyDigest, { WeeklyDigestSubject } from "./templates/WeeklyDigest";
-
-import { transformUserPreview } from "../user/user.transformer";
 
 @Injectable()
 export class EmailService {
@@ -125,7 +121,7 @@ export class EmailService {
       MAX_REC_PER_MAIL,
       filter
     );
-    return dbRecs.map((dbRec) => this.getRecFromDbRec(dbRec));
+    return dbRecs.map((dbRec) => transformRec(dbRec));
   }
 
   private async sendWeeklyDigest(
@@ -155,17 +151,5 @@ export class EmailService {
     }
 
     return result;
-  }
-
-  private getRecFromDbRec(dbRec: DbRec): Rec {
-    return {
-      ...dbRec,
-      cutoff: dbRec.cutoff.toISOString(),
-      user: transformUserPreview(dbRec.user),
-      reactions: {
-        selfReactions: [],
-        numReactions: [],
-      },
-    };
   }
 }

--- a/apps/recnet-api/src/modules/rec/entities/rec.entity.ts
+++ b/apps/recnet-api/src/modules/rec/entities/rec.entity.ts
@@ -2,7 +2,25 @@ import { ApiProperty } from "@nestjs/swagger";
 
 import { Article } from "@recnet-api/modules/article/entities/article.entity";
 
+import { ReactionType } from "@recnet/recnet-api-model";
+
 import { UserPreview } from "../../user/entities/user.preview.entity";
+
+class NumReaction {
+  @ApiProperty()
+  type: ReactionType;
+
+  @ApiProperty()
+  count: number;
+}
+
+class Reactions {
+  @ApiProperty()
+  selfReactions: ReactionType[];
+
+  @ApiProperty()
+  numReactions: NumReaction[];
+}
 
 export class Rec {
   @ApiProperty()
@@ -22,4 +40,7 @@ export class Rec {
 
   @ApiProperty()
   article: Article;
+
+  @ApiProperty()
+  reactions: Reactions;
 }

--- a/apps/recnet-api/src/modules/rec/rec.controller.ts
+++ b/apps/recnet-api/src/modules/rec/rec.controller.ts
@@ -17,9 +17,9 @@ import {
   ApiTags,
 } from "@nestjs/swagger";
 
-import { Auth } from "@recnet-api/utils/auth/auth.decorator";
-import { AuthUser } from "@recnet-api/utils/auth/auth.type";
-import { User } from "@recnet-api/utils/auth/auth.user.decorator";
+import { Auth, AuthOptional } from "@recnet-api/utils/auth/auth.decorator";
+import { AuthUser, AuthOptionalUser } from "@recnet-api/utils/auth/auth.type";
+import { User, UserOptional } from "@recnet-api/utils/auth/auth.user.decorator";
 import { RecnetExceptionFilter } from "@recnet-api/utils/filters/recnet.exception.filter";
 import {
   ZodValidationBodyPipe,
@@ -63,9 +63,14 @@ export class RecController {
     summary: "Get a single rec",
     description: "Get a single rec by id.",
   })
+  @ApiBearerAuth()
   @ApiOkResponse({ type: GetRecResponse })
   @Get("rec/:id")
-  public async getRec(@Param("id") id: string): Promise<GetRecResponse> {
+  @AuthOptional()
+  public async getRec(
+    @Param("id") id: string,
+    @UserOptional() authUser: AuthOptionalUser
+  ): Promise<GetRecResponse> {
     return this.recService.getRec(id);
   }
 
@@ -76,8 +81,12 @@ export class RecController {
   @ApiOkResponse({ type: GetRecsResponse })
   @ApiBearerAuth()
   @Get()
+  @AuthOptional()
   @UsePipes(new ZodValidationQueryPipe(getRecsParamsSchema))
-  public async getRecs(@Query() dto: QueryRecsDto): Promise<GetRecsResponse> {
+  public async getRecs(
+    @Query() dto: QueryRecsDto,
+    @UserOptional() authUser: AuthOptionalUser
+  ): Promise<GetRecsResponse> {
     const { page, pageSize, userId } = dto;
 
     // Get the Recs to current date to avoid upcoming rec from showing in a user's profile page

--- a/apps/recnet-api/src/modules/rec/rec.controller.ts
+++ b/apps/recnet-api/src/modules/rec/rec.controller.ts
@@ -71,7 +71,7 @@ export class RecController {
     @Param("id") id: string,
     @UserOptional() authUser: AuthOptionalUser
   ): Promise<GetRecResponse> {
-    const authUserId = authUser ? authUser.userId : null;
+    const authUserId = authUser?.userId ?? null;
     return this.recService.getRec(id, authUserId);
   }
 
@@ -89,7 +89,7 @@ export class RecController {
     @UserOptional() authUser: AuthOptionalUser
   ): Promise<GetRecsResponse> {
     const { page, pageSize, userId } = dto;
-    const authUserId = authUser ? authUser.userId : null;
+    const authUserId = authUser?.userId ?? null;
 
     // Get the Recs to current date to avoid upcoming rec from showing in a user's profile page
     const to = new Date();

--- a/apps/recnet-api/src/modules/rec/rec.controller.ts
+++ b/apps/recnet-api/src/modules/rec/rec.controller.ts
@@ -71,7 +71,8 @@ export class RecController {
     @Param("id") id: string,
     @UserOptional() authUser: AuthOptionalUser
   ): Promise<GetRecResponse> {
-    return this.recService.getRec(id);
+    const authUserId = authUser ? authUser.userId : null;
+    return this.recService.getRec(id, authUserId);
   }
 
   @ApiOperation({
@@ -88,10 +89,11 @@ export class RecController {
     @UserOptional() authUser: AuthOptionalUser
   ): Promise<GetRecsResponse> {
     const { page, pageSize, userId } = dto;
+    const authUserId = authUser ? authUser.userId : null;
 
     // Get the Recs to current date to avoid upcoming rec from showing in a user's profile page
     const to = new Date();
-    return this.recService.getRecs(page, pageSize, userId, to);
+    return this.recService.getRecs(page, pageSize, userId, to, authUserId);
   }
 
   @ApiOperation({

--- a/apps/recnet-api/src/modules/rec/rec.transformer.ts
+++ b/apps/recnet-api/src/modules/rec/rec.transformer.ts
@@ -1,0 +1,46 @@
+import { ReactionType } from "@prisma/client";
+
+import {
+  Rec as DbRec,
+  RecReaction as DbRecReaction,
+} from "@recnet-api/database/repository/rec.repository.type";
+import { transformUserPreview } from "@recnet-api/modules/user/user.transformer";
+
+import { Rec } from "./entities/rec.entity";
+
+export const transformRec = (
+  dbRec: DbRec,
+  authUserId: string | null = null
+): Rec => {
+  let selfReactions: ReactionType[] = [];
+  if (authUserId) {
+    selfReactions = dbRec.reactions
+      .filter((reaction) => reaction.userId == authUserId)
+      .map((reaction) => reaction.reaction);
+  }
+
+  const reactionCounts = dbRec.reactions.reduce(
+    (acc: Record<ReactionType, number>, reaction: DbRecReaction) => {
+      if (!acc[reaction.reaction]) {
+        acc[reaction.reaction] = 0;
+      }
+      acc[reaction.reaction] += 1;
+      return acc;
+    },
+    {} as Record<ReactionType, number>
+  );
+  const numReactions = Object.keys(reactionCounts).map((reactionType) => ({
+    type: reactionType as ReactionType,
+    count: reactionCounts[reactionType as ReactionType],
+  }));
+
+  return {
+    ...dbRec,
+    cutoff: dbRec.cutoff.toISOString(),
+    user: transformUserPreview(dbRec.user),
+    reactions: {
+      selfReactions,
+      numReactions,
+    },
+  };
+};

--- a/apps/recnet-api/src/utils/auth/auth.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.decorator.ts
@@ -16,12 +16,21 @@ export const Auth = (
   } = {}
 ) => {
   const { allowNonActivated = false, allowedRoles = ["USER", "ADMIN"] } = opts;
+  const isOptional = false;
 
   return applyDecorators(
-    UseGuards(new AuthGuard(verifyRecnetJwt)),
+    UseGuards(AuthGuard(verifyRecnetJwt, isOptional)),
     UseGuards(ActivatedGuard(allowNonActivated)),
     UseGuards(RoleGuard(allowedRoles))
   );
 };
 
-export const AuthFirebase = () => UseGuards(new AuthGuard(verifyFirebaseJwt));
+export const AuthOptional = () => {
+  const isOptional = true;
+  return UseGuards(AuthGuard(verifyRecnetJwt, isOptional));
+};
+
+export const AuthFirebase = () => {
+  const isOptional = false;
+  return UseGuards(AuthGuard(verifyFirebaseJwt, isOptional));
+};

--- a/apps/recnet-api/src/utils/auth/auth.guard.ts
+++ b/apps/recnet-api/src/utils/auth/auth.guard.ts
@@ -1,7 +1,7 @@
 import {
   CanActivate,
   ExecutionContext,
-  Injectable,
+  mixin,
   UnauthorizedException,
 } from "@nestjs/common";
 import { Request } from "express";
@@ -10,29 +10,40 @@ import { getPublicKey } from "@recnet/recnet-jwt";
 
 import { VerifyJwtFunction } from "./auth.type";
 
-@Injectable()
-export class AuthGuard implements CanActivate {
-  constructor(private readonly verifyJwt: VerifyJwtFunction) {}
+export const AuthGuard = (
+  verifyJwt: VerifyJwtFunction,
+  isOptional: boolean
+) => {
+  class AuthGuardMixin implements CanActivate {
+    async canActivate(context: ExecutionContext) {
+      const request = context.switchToHttp().getRequest();
+      const token = this.extractTokenFromHeader(request);
 
-  async canActivate(context: ExecutionContext) {
-    const request = context.switchToHttp().getRequest();
-    const token = this.extractTokenFromHeader(request);
+      if (!token) {
+        if (isOptional) {
+          return true;
+        }
+        throw new UnauthorizedException();
+      }
 
-    if (!token) {
-      throw new UnauthorizedException();
+      try {
+        const publicKey = await getPublicKey(token);
+        const payload = verifyJwt(token, publicKey);
+        request.user = payload;
+      } catch (error) {
+        if (isOptional) {
+          return true;
+        }
+        throw new UnauthorizedException();
+      }
+      return true;
     }
-    try {
-      const publicKey = await getPublicKey(token);
-      const payload = this.verifyJwt(token, publicKey);
-      request.user = payload;
-    } catch (error) {
-      throw new UnauthorizedException();
-    }
-    return true;
-  }
 
-  private extractTokenFromHeader(request: Request): string | undefined {
-    const [type, token] = request.headers.authorization?.split(" ") ?? [];
-    return type === "Bearer" ? token : undefined;
+    private extractTokenFromHeader(request: Request): string | undefined {
+      const [type, token] = request.headers.authorization?.split(" ") ?? [];
+      return type === "Bearer" ? token : undefined;
+    }
   }
-}
+  const guard = mixin(AuthGuardMixin);
+  return guard;
+};

--- a/apps/recnet-api/src/utils/auth/auth.type.ts
+++ b/apps/recnet-api/src/utils/auth/auth.type.ts
@@ -17,6 +17,8 @@ export type AuthUser<
   ? RecNetJwtPayload["recnet"][Prop]
   : RecNetJwtPayload["recnet"];
 
+export type AuthOptionalUser = AuthUser | null;
+
 export type AuthFirebaseUser = {
   provider: AuthProvider;
   providerId: string;

--- a/apps/recnet-api/src/utils/auth/auth.user.decorator.ts
+++ b/apps/recnet-api/src/utils/auth/auth.user.decorator.ts
@@ -34,6 +34,20 @@ export const User = createParamDecorator<
   return prop ? recnetUser[prop] : recnetUser;
 });
 
+export const UserOptional = createParamDecorator<
+  RecNetJwtPayloadProps | undefined,
+  ExecutionContext
+>((prop, ctx) => {
+  const request = ctx.switchToHttp().getRequest();
+  const recnetJwtPayload = recnetJwtPayloadSchema.safeParse(request.user);
+  if (!recnetJwtPayload.success) {
+    return null;
+  }
+  const recnetUser = recnetJwtPayload.data.recnet;
+
+  return prop ? recnetUser[prop] : recnetUser;
+});
+
 export const FirebaseUser = createParamDecorator<undefined, ExecutionContext>(
   (_, ctx): AuthFirebaseUser => {
     const request = ctx.switchToHttp().getRequest();

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -63,6 +63,15 @@ export const recSchema = z.object({
   cutoff: dateSchema,
   user: userPreviewSchema,
   article: articleSchema,
+  reactions: z.object({
+    selfReactions: z.array(reactionTypeSchema),
+    numReactions: z.array(
+      z.object({
+        type: reactionTypeSchema,
+        count: z.number(),
+      })
+    ),
+  }),
 });
 export type Rec = z.infer<typeof recSchema>;
 


### PR DESCRIPTION
## Description

Add rec reaction to rec related API.
Design Doc: [Notion](https://www.notion.so/Rec-Emoji-Reaction-ad4c0db048574a6183a672b25d209e5c)

- GET /recs/rec/{id}
- GET /recs
- GET /recs/feed

The Rec schema in response API becomes:
```
{
    "id": "string",
    "description": "string",
    ...
    "reaction": {
		  "selfReactions": ["string"],  // list emun of reaction that user clicked
		  "numReactions": [
		     {
			     "type": "string",  // enum of reaction
			     "count": "number" // total count of the reaction
		     }
		  ]
    }
}
```

## Related Issue

- https://github.com/lil-lab/recnet/issues/60

## Notes

<!-- Other thing to say -->
As `GET /recs/rec/{id}` and `GET /recs/` do not require an Auth user to login, I added a decorator of `@AuthOptional` to get the user information from jwt token.

## Test

1. Hit `POST /recs/{id}/reactions` and `DELETE /recs/{id}/reactions` to create and delete rec for a specific Recommendation.
2. Use the API above to query recs and validate if the `reactions` field is returned correctly.
3. Try to create rec reactions with different users to test if selfReactions and numReactions work correctly.

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
