### PR TITLE
[recnet-release-action] cache gh action build output

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -3,8 +3,8 @@ name: RecNet Prod-Release Pipeline
 on:
   workflow_dispatch: {}
   push:
-    # branches:
-    #   - dev
+    branches:
+      - dev
 
 jobs:
   release:

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -3,8 +3,8 @@ name: RecNet Prod-Release Pipeline
 on:
   workflow_dispatch: {}
   push:
-    branches:
-      - dev
+    # branches:
+    #   - dev
 
 jobs:
   release:

--- a/libs/recnet-release-action/action.yml
+++ b/libs/recnet-release-action/action.yml
@@ -24,19 +24,46 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
+
     - uses: pnpm/action-setup@v2
       with:
         version: 8.15.5
+
     - uses: actions/setup-node@v3
       with:
         node-version: 20
         cache: "pnpm"
-    - run: pnpm install --frozen-lockfile
+
+    - name: Get hash of source files
+      id: hash
+      run: echo "hash=$(bash ./libs/recnet-release-action/scripts/hash_source.sh)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache build output
+      uses: actions/cache@v3
+      id: cache
+      with:
+        path: ./libs/recnet-release-action/dist
+        key: ${{ runner.os }}-recnet-release-action-${{ steps.hash.outputs.hash }}
+
+    - name: Display hash and cache status
+      run: |
+        echo "Source hash: ${{ steps.hash.outputs.hash }}"
+        echo "Cache hit: ${{ steps.cache.outputs.cache-hit == 'true' && 'Yes' || 'No' }}"
+      shell: bash
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: pnpm install --frozen-lockfile
       shell: sh
-    - run: pnpm nx build recnet-release-action
+
+    - name: Build
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: pnpm nx build recnet-release-action
       shell: sh
       env:
         NX_NO_CLOUD: true
+
     - run: |
         export GITHUB_TOKEN="${{ inputs.github-token }}"
         export HEAD_BRANCH="${{ inputs.head-branch }}"

--- a/libs/recnet-release-action/scripts/hash_source.sh
+++ b/libs/recnet-release-action/scripts/hash_source.sh
@@ -1,0 +1,8 @@
+# Change to the src directory
+cd "$(dirname "$0")/../src" || exit 1
+
+# Calculate hash of all files in the src directory
+hash=$(find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)
+
+# Output the hash
+echo "$hash"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Cache the output of `nx build recnet-release-action` using the hash of source code in `libs/recnet-release-action/src` to accelerate gh action

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
Successful run 1 (cache miss): https://github.com/lil-lab/recnet/actions/runs/11335345342/attempts/1
Successful run 2 (cache hit): https://github.com/lil-lab/recnet/actions/runs/11335345342


## Test

<!--- Please describe in detail how you tested your changes locally. -->

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

You can see in the first run, cache doesn't hit, and the action start downloading node packages and compiling the typescript files.

![Screenshot 2024-10-14 at 5 41 54 PM](https://github.com/user-attachments/assets/616cd891-ec46-48e7-8b51-fb889e240413)

And it saves the output in cache in the end of first successful run.

![Screenshot 2024-10-14 at 5 43 45 PM](https://github.com/user-attachments/assets/b4fb5a44-493c-496c-8c71-26351a450be0)

In the second run, you can see it did hit the cache and skip the downloading and compiiing steps
![Screenshot 2024-10-14 at 5 44 37 PM](https://github.com/user-attachments/assets/fe5fd532-8359-4bcd-a136-acbcc67f1ed8)

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
