### PR TITLE
[recnet-web] Rec reactions UI

### DIFF
--- a/apps/recnet/src/app/rec/[id]/RecPageContent.tsx
+++ b/apps/recnet/src/app/rec/[id]/RecPageContent.tsx
@@ -7,6 +7,7 @@ import { LinkPreview } from "@recnet/recnet-web/components/LinkPreview";
 import { SelfRecBadge } from "@recnet/recnet-web/components/SelfRecBadge";
 
 import { formatDate } from "@recnet/recnet-date-fns";
+import { RecReactionsList } from "./RecReactionsList";
 
 const fallbackImage =
   "https://recnet.io/_next/image?url=%2Frecnet-logo.webp&w=64&q=100";
@@ -54,6 +55,7 @@ export async function RecPageContent(props: { id: string }) {
           fallbackImage
         }
       />
+      <RecReactionsList id={id} />
     </div>
   );
 }

--- a/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
+++ b/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
@@ -29,7 +29,7 @@ function ReactionButton(props: { onSelect: (reaction: ReactionType) => void }) {
   return (
     <Popover.Root>
       <Popover.Trigger>
-        <div className="cursor-pointer rounded-[999px] mx-1 p-2 bg-gray-4">
+        <div className="cursor-pointer rounded-[999px] mr-1 p-2 bg-gray-4">
           <FaceIcon width="16" height="16" className="text-gray-11" />
         </div>
       </Popover.Trigger>

--- a/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
+++ b/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
@@ -1,0 +1,147 @@
+"use client";
+import { FaceIcon } from "@radix-ui/react-icons";
+import { Popover, Button, Flex, Spinner } from "@radix-ui/themes";
+import { toast } from "sonner";
+
+import { useAuth } from "@recnet/recnet-web/app/AuthContext";
+import { trpc } from "@recnet/recnet-web/app/_trpc/client";
+import { cn } from "@recnet/recnet-web/utils/cn";
+
+import { ReactionType, reactionTypeSchema } from "@recnet/recnet-api-model";
+
+const reactionEmojiMap: Record<ReactionType, string> = {
+  THUMBS_UP: "👍",
+  THINKING: "🤔",
+  SURPRISED: "😲",
+  CRYING: "😢",
+  STARRY_EYES: "🤩",
+  MINDBLOWN: "🤯",
+  EYES: "👀",
+  ROCKET: "🚀",
+  HEART: "❤️",
+  PRAY: "🙏",
+  PARTY: "🎉",
+};
+
+function ReactionButton(props: { onSelect: (reaction: ReactionType) => void }) {
+  const { onSelect } = props;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger>
+        <div className="cursor-pointer rounded-[999px] mx-1 p-2 bg-gray-4">
+          <FaceIcon width="16" height="16" className="text-gray-11" />
+        </div>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Flex>
+          {reactionTypeSchema.options.map((reaction) => (
+            <Popover.Close key={reaction}>
+              <Button
+                variant="ghost"
+                className="cursor-pointer hover:bg-blue-6 mx-0"
+                onClick={() => {
+                  onSelect(reaction);
+                }}
+              >
+                {reactionEmojiMap[reaction]}
+              </Button>
+            </Popover.Close>
+          ))}
+        </Flex>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}
+
+function ReactionChip(props: {
+  onClick: (reaction: ReactionType) => void;
+  reaction: ReactionType;
+  count: number;
+  isSelected?: boolean;
+}) {
+  const { onClick, reaction, count, isSelected = false } = props;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-row cursor-pointer rounded-[99px] px-2 py-1 items-center text-[14px] gap-x-2 transition-colors ease-in-out border-[1px]",
+        isSelected
+          ? "border-blue-6 bg-blue-4 hover:border-blue-8"
+          : "border-gray-6 bg-gray-4 hover:border-gray-8"
+      )}
+      onClick={() => {
+        onClick(reaction);
+      }}
+    >
+      <div>{reactionEmojiMap[reaction]}</div>
+      <div>{count}</div>
+    </div>
+  );
+}
+
+export function RecReactionsList(props: { id: string }) {
+  const { id } = props;
+  const { user } = useAuth();
+  const { data, isLoading, refetch } = trpc.getRecById.useQuery({
+    id,
+  });
+
+  const addReactionMutation = trpc.addReaction.useMutation();
+  const removeReactionMutation = trpc.removeReaction.useMutation();
+
+  const onClickReaction = async (reaction: ReactionType) => {
+    if (isLoading || !data) {
+      return;
+    }
+    if (!user) {
+      toast.error("You need to be logged in to react");
+      return;
+    }
+    // if yes, send reaction mutation
+    // if this reaction is already selected, remove it
+    // else, add it
+    const isReactionSelected =
+      data.rec.reactions.selfReactions.includes(reaction);
+    if (isReactionSelected) {
+      await removeReactionMutation.mutateAsync({
+        recId: id,
+        reaction,
+      });
+    } else {
+      await addReactionMutation.mutateAsync({
+        recId: id,
+        reaction,
+      });
+    }
+    // refresh the list
+    refetch();
+  };
+
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-2">
+      <ReactionButton onSelect={onClickReaction} />
+      {isLoading ? (
+        <Spinner />
+      ) : !data ? null : (
+        data.rec.reactions.numReactions.map((reactionCountPair) => {
+          return (
+            <ReactionChip
+              key={reactionCountPair.type}
+              onClick={onClickReaction}
+              reaction={reactionCountPair.type}
+              count={reactionCountPair.count}
+              isSelected={
+                !user
+                  ? false
+                  : data.rec.reactions.selfReactions.includes(
+                      reactionCountPair.type
+                    )
+              }
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/apps/recnet/src/components/RecCard.tsx
+++ b/apps/recnet/src/components/RecCard.tsx
@@ -17,6 +17,7 @@ import { LinkCopyButton } from "./LinkCopyButton";
 import { SelfRecBadge } from "./SelfRecBadge";
 
 import { getSharableLink } from "../utils/getSharableRecLink";
+import { RecReactionsList } from "../app/rec/[id]/RecReactionsList";
 
 export function RecCardSkeleton() {
   return (
@@ -152,6 +153,9 @@ export function RecCard(props: { recs: Rec[]; showDate?: boolean }) {
                   </Text>
                 </Flex>
               </Link>
+              <div className="mt-2">
+                <RecReactionsList id={rec.id} />
+              </div>
             </Flex>
           </Flex>
         );

--- a/apps/recnet/src/server/routers/middleware.ts
+++ b/apps/recnet/src/server/routers/middleware.ts
@@ -108,6 +108,32 @@ export const checkRecnetJWTProcedure = publicProcedure.use(async (opts) => {
   });
 });
 
+export const checkOptionalRecnetJWTProcedure = publicProcedure.use(
+  async (opts) => {
+    const tokens = await getTokenServerSide();
+    const parseRes = recnetTokenSchema.safeParse(tokens);
+    if (!tokens || !parseRes.success) {
+      // if no token, just continue
+      return opts.next({
+        ctx: {
+          ...opts.ctx,
+        },
+      });
+    }
+    const user = await getUserByTokens();
+    const recnetApiInstance = createRecnetApiInstanceWithToken(tokens);
+
+    return opts.next({
+      ctx: {
+        ...opts.ctx,
+        tokens: parseRes.data,
+        user: user,
+        recnetApi: recnetApiInstance,
+      },
+    });
+  }
+);
+
 export const checkIsAdminProcedure = publicProcedure.use(async (opts) => {
   const tokens = await getTokenServerSide();
   const parseRes = recnetJwtPayloadSchema.safeParse(tokens?.decodedToken);

--- a/apps/recnet/src/server/routers/rec.ts
+++ b/apps/recnet/src/server/routers/rec.ts
@@ -117,7 +117,7 @@ export const recRouter = router({
     .mutation(async (opts) => {
       const { recnetApi } = opts.ctx;
       const { recId, reaction } = opts.input;
-      await recnetApi.post(`/recs/rec/${recId}/reactions`, {
+      await recnetApi.post(`/recs/${recId}/reactions`, {
         reaction,
       });
     }),
@@ -130,7 +130,7 @@ export const recRouter = router({
     .mutation(async (opts) => {
       const { recnetApi } = opts.ctx;
       const { recId, reaction } = opts.input;
-      await recnetApi.delete(`/recs/rec/${recId}/reactions`, {
+      await recnetApi.delete(`/recs/${recId}/reactions`, {
         params: {
           ...deleteRecReactionParamsSchema.parse({ reaction }),
         },

--- a/apps/recnet/src/server/routers/rec.ts
+++ b/apps/recnet/src/server/routers/rec.ts
@@ -14,14 +14,14 @@ import {
 
 import {
   checkIsAdminProcedure,
+  checkOptionalRecnetJWTProcedure,
   checkRecnetJWTProcedure,
-  publicApiProcedure,
 } from "./middleware";
 
 import { router } from "../trpc";
 
 export const recRouter = router({
-  getRecById: publicApiProcedure
+  getRecById: checkOptionalRecnetJWTProcedure
     .input(
       z.object({
         id: z.string(),
@@ -33,7 +33,7 @@ export const recRouter = router({
       const { data } = await recnetApi.get(`/recs/rec/${opts.input.id}`);
       return getRecIdResponseSchema.parse(data);
     }),
-  getHistoricalRecs: publicApiProcedure
+  getHistoricalRecs: checkOptionalRecnetJWTProcedure
     .input(
       z.object({
         userId: z.string(),

--- a/apps/recnet/src/server/routers/rec.ts
+++ b/apps/recnet/src/server/routers/rec.ts
@@ -10,6 +10,8 @@ import {
   postRecsUpcomingRequestSchema,
   patchRecsUpcomingRequestSchema,
   getRecIdResponseSchema,
+  postRecsReactionsRequestSchema,
+  deleteRecReactionParamsSchema,
 } from "@recnet/recnet-api-model";
 
 import {
@@ -106,6 +108,34 @@ export const recRouter = router({
     const { recnetApi } = opts.ctx;
     await recnetApi.delete(`/recs/upcoming`);
   }),
+  addReaction: checkRecnetJWTProcedure
+    .input(
+      postRecsReactionsRequestSchema.extend({
+        recId: z.string(),
+      })
+    )
+    .mutation(async (opts) => {
+      const { recnetApi } = opts.ctx;
+      const { recId, reaction } = opts.input;
+      await recnetApi.post(`/recs/rec/${recId}/reactions`, {
+        reaction,
+      });
+    }),
+  removeReaction: checkRecnetJWTProcedure
+    .input(
+      deleteRecReactionParamsSchema.extend({
+        recId: z.string(),
+      })
+    )
+    .mutation(async (opts) => {
+      const { recnetApi } = opts.ctx;
+      const { recId, reaction } = opts.input;
+      await recnetApi.delete(`/recs/rec/${recId}/reactions`, {
+        params: {
+          ...deleteRecReactionParamsSchema.parse({ reaction }),
+        },
+      });
+    }),
   getNumOfRecs: checkIsAdminProcedure
     .output(
       z.object({


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add reactions buttons under rec page

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #60 

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->
Find a rec and go to rec page `rec/:id`
- When not logged in, should be able to view reactions. But when clicking emojis, should see an error toast shows up.
- When logged in, should be able to select reaction. And after selection, should see the reaction chip, which displays how many users have clicked that reaction, displays the number correctly.
- When click again (no matter using the reaction popover or click on reaction chip), should remove that reaction (reaction count decrement by 1)

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->
![Screenshot 2024-10-15 at 12 42 48 AM](https://github.com/user-attachments/assets/7ff0f015-4062-4be2-bed8-04493cd647a4)

Reaction popover:
![Screenshot 2024-10-15 at 12 46 35 AM](https://github.com/user-attachments/assets/9696fa58-573e-42d8-86a7-1647594f0939)

Reaction chip:
![Screenshot 2024-10-15 at 12 46 49 AM](https://github.com/user-attachments/assets/f24542a6-2869-42e3-9954-2432a11b4105)


## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
