### PR TITLE
[recnet-api] Get abstract from arXiv

### DIFF
--- a/apps/recnet-api/prisma/migrations/20241021180415_add_article_abstract/down.sql
+++ b/apps/recnet-api/prisma/migrations/20241021180415_add_article_abstract/down.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Article" DROP COLUMN "abstract";
+

--- a/apps/recnet-api/prisma/migrations/20241021180415_add_article_abstract/migration.sql
+++ b/apps/recnet-api/prisma/migrations/20241021180415_add_article_abstract/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN     "abstract" TEXT;

--- a/apps/recnet-api/prisma/schema.prisma
+++ b/apps/recnet-api/prisma/schema.prisma
@@ -113,6 +113,7 @@ model Article {
   year       Int      @db.SmallInt
   month      Int?     @db.SmallInt
   isVerified Boolean  @default(false)
+  abstract   String?  @db.Text
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
 

--- a/apps/recnet-api/src/database/repository/article.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/article.repository.type.ts
@@ -9,11 +9,16 @@ export const article = Prisma.validator<Prisma.ArticleDefaultArgs>()({
     link: true,
     year: true,
     month: true,
+    abstract: true,
     isVerified: true,
   },
 });
 export type Article = Prisma.ArticleGetPayload<typeof article>;
 
-export type CreateArticleInput = Omit<Article, "id" | "isVerified"> & {
+export type CreateArticleInput = Omit<
+  Article,
+  "id" | "isVerified" | "abstract"
+> & {
+  abstract?: string;
   isVerified?: boolean;
 };

--- a/apps/recnet-api/src/modules/article/article.controller.ts
+++ b/apps/recnet-api/src/modules/article/article.controller.ts
@@ -24,7 +24,8 @@ export class ArticleController {
 
   @ApiOperation({
     summary: "Get Article By Link",
-    description: "Get article by link.",
+    description:
+      "Get article by link. If the article is not found in the database, it will try to get metadata using the digital library service. Now it only supports arXiv.",
   })
   @ApiOkResponse({ type: GetArticleByLinkResponse })
   @ApiBearerAuth()

--- a/apps/recnet-api/src/modules/article/article.response.ts
+++ b/apps/recnet-api/src/modules/article/article.response.ts
@@ -3,6 +3,6 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Article } from "./entities/article.entity";
 
 export class GetArticleByLinkResponse {
-  @ApiProperty()
+  @ApiProperty({ type: Article, nullable: true })
   article: Article | null;
 }

--- a/apps/recnet-api/src/modules/article/entities/article.entity.ts
+++ b/apps/recnet-api/src/modules/article/entities/article.entity.ts
@@ -23,5 +23,8 @@ export class Article {
   month: number | null;
 
   @ApiProperty()
+  abstract: string | null;
+
+  @ApiProperty()
   isVerified: boolean;
 }

--- a/apps/recnet-api/src/modules/digital-library/arxiv.service.ts
+++ b/apps/recnet-api/src/modules/digital-library/arxiv.service.ts
@@ -122,6 +122,7 @@ export class ArXivService implements DigitalLibraryService {
     }
 
     const date = new Date(publishDate);
+    const abstract: string | null = get(parsed, "feed.entry.summary", null);
 
     const metadata: ArXivMetadata = {
       title,
@@ -132,6 +133,7 @@ export class ArXivService implements DigitalLibraryService {
         : (authors as { name: string }).name,
       year: date.getFullYear(),
       month: date.getMonth(),
+      abstract: abstract ?? undefined,
     };
 
     return metadata;

--- a/apps/recnet-api/src/modules/digital-library/digital-library.type.ts
+++ b/apps/recnet-api/src/modules/digital-library/digital-library.type.ts
@@ -3,6 +3,7 @@ export type Metadata = {
   author: string;
   year: number;
   month: number;
+  abstract?: string;
   isVerified: boolean;
 };
 

--- a/apps/recnet-api/src/modules/digital-library/specs/arxiv.service.spec.ts
+++ b/apps/recnet-api/src/modules/digital-library/specs/arxiv.service.spec.ts
@@ -209,6 +209,29 @@ describe("ArXivService", () => {
         )
       );
     });
+
+    it("should include abstract if available", async () => {
+      (axios.get as jest.Mock).mockResolvedValue({
+        data: "<xml><feed><entry><title>Sample Title</title><author><name>Author 1</name></author><published>2023-09-18T00:00:00Z</published><summary>Sample abstract</summary></entry></feed></xml>",
+      });
+
+      (XMLParser.prototype.parse as jest.Mock).mockReturnValue({
+        feed: {
+          entry: {
+            title: "Sample Title",
+            author: { name: "Author 1" },
+            published: "2023-09-18T00:00:00Z",
+            summary: "Sample abstract",
+          },
+        },
+      });
+
+      const mockArXivId = "2409.11377v1";
+      const link = `https://arxiv.org/abs/${mockArXivId}`;
+      const metadata = await service.getMetadata(link);
+
+      expect(metadata.abstract).toEqual("Sample abstract");
+    });
   });
 
   describe("getUnifiedLink", () => {

--- a/apps/recnet-api/src/modules/rec/dto/create.rec.dto.ts
+++ b/apps/recnet-api/src/modules/rec/dto/create.rec.dto.ts
@@ -5,6 +5,7 @@ import { Article } from "@recnet-api/modules/article/entities/article.entity";
 export class CreateArticleDto extends OmitType(Article, [
   "id",
   "isVerified",
+  "abstract",
 ] as const) {}
 
 export class CreateRecDto {

--- a/apps/recnet-api/src/modules/rec/dto/update.rec.dto.ts
+++ b/apps/recnet-api/src/modules/rec/dto/update.rec.dto.ts
@@ -5,6 +5,7 @@ import { Article } from "@recnet-api/modules/article/entities/article.entity";
 export class UpdateArticleDto extends OmitType(Article, [
   "id",
   "isVerified",
+  "abstract",
 ] as const) {}
 
 export class UpdateRecDto {

--- a/apps/recnet/src/components/rec/NewArticleForm.tsx
+++ b/apps/recnet/src/components/rec/NewArticleForm.tsx
@@ -256,6 +256,7 @@ export function NewArticleForm(props: {
                     author: res.data.author,
                     year: res.data.year,
                     month: res.data.month ?? null,
+                    abstract: null,
                   },
                   description: res.data.description,
                   isSelfRec: res.data.isSelfRec,

--- a/apps/recnet/src/components/rec/NewArticleForm.tsx
+++ b/apps/recnet/src/components/rec/NewArticleForm.tsx
@@ -256,7 +256,6 @@ export function NewArticleForm(props: {
                     author: res.data.author,
                     year: res.data.year,
                     month: res.data.month ?? null,
-                    abstract: null,
                   },
                   description: res.data.description,
                   isSelfRec: res.data.isSelfRec,

--- a/libs/recnet-api-model/src/lib/api/rec.ts
+++ b/libs/recnet-api-model/src/lib/api/rec.ts
@@ -10,7 +10,11 @@ export const recFormSubmissionSchema = z.intersection(
     }),
     z.object({
       articleId: z.null(),
-      article: articleSchema.omit({ id: true, isVerified: true }),
+      article: articleSchema.omit({
+        id: true,
+        isVerified: true,
+        abstract: true,
+      }),
     }),
   ]),
   z.object({

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -52,6 +52,7 @@ export const articleSchema = z.object({
   link: z.string().url(),
   year: z.number(),
   month: z.number().min(0).max(11).nullable(),
+  abstract: z.string().nullable(),
   isVerified: z.boolean(),
 });
 export type Article = z.infer<typeof articleSchema>;


### PR DESCRIPTION
## Description

Get the paper abstract from arXiv.

## Related Issue

- https://github.com/lil-lab/recnet/issues/334

## Notes

<!-- Other thing to say -->

## Test

Use `GET /article?link={arXiv URL}` to test this feature. The response should contain the abstract of the article.

## Screenshots (if appropriate):

<img width="852" alt="Screenshot 2024-10-21 at 4 31 35 PM" src="https://github.com/user-attachments/assets/9b141be4-42e8-4374-881a-1d2cca050f82">


## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
