### PR TITLE
[recnet-web] Cover uncovered case in reaction optimistic UI

### DIFF
--- a/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
+++ b/apps/recnet/src/app/rec/[id]/RecReactionsList.tsx
@@ -115,17 +115,24 @@ export function RecReactionsList(props: { id: string }) {
               ...previousData.rec,
               reactions: {
                 ...previousData.rec.reactions,
-                numReactions: previousData.rec.reactions.numReactions.map(
-                  (reactionCountPair) => {
-                    if (reactionCountPair.type === reaction) {
-                      return {
-                        type: reaction,
-                        count: reactionCountPair.count + 1,
-                      };
-                    }
-                    return reactionCountPair;
-                  }
-                ),
+                numReactions: previousData.rec.reactions.numReactions.some(
+                  (pair) => pair.type === reaction
+                )
+                  ? previousData.rec.reactions.numReactions.map(
+                      (reactionCountPair) => {
+                        if (reactionCountPair.type === reaction) {
+                          return {
+                            type: reaction,
+                            count: reactionCountPair.count + 1,
+                          };
+                        }
+                        return reactionCountPair;
+                      }
+                    )
+                  : [
+                      ...previousData.rec.reactions.numReactions,
+                      { type: reaction, count: 1 },
+                    ],
                 selfReactions: [
                   ...previousData.rec.reactions.selfReactions,
                   reaction,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In optimistic UI, we always assume the mutation API will be successfully and predict the next state of UI and render it first before we get the API response. 

In our case, for clicking a new reaction, I forget to cover one case, that is, the current user is the first one clicking that reaction. 

This PR added this case to improve UX.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #60 

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->
You should feel the UI updating "immediately" after you clicked a reaction (even if you are the first one who click that reaction).


## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
