### PR TITLE
[recnet-web] Adjust og and metadata desc

### DIFF
--- a/apps/recnet/src/app/[handle]/opengraph-image.tsx
+++ b/apps/recnet/src/app/[handle]/opengraph-image.tsx
@@ -6,8 +6,8 @@ import { cn } from "@recnet/recnet-web/utils/cn";
 // Image metadata
 export const alt = "User Profile";
 export const size = {
-  width: 1200,
-  height: 630,
+  width: 1600,
+  height: 900,
 };
 
 export const contentType = "image/png";
@@ -40,7 +40,7 @@ export default async function Image({
           "flex flex-col justify-start bg-white w-full h-full",
           "p-8",
           "gap-y-2",
-          "text-[32px]"
+          "text-[48px]"
         )}
       >
         <div tw="flex flex-row items-center">
@@ -50,13 +50,15 @@ export default async function Image({
             tw="w-10 h-10 mr-4"
             alt={"recnet-logo"}
           />
-          <p tw={cn("text-[24px] text-[#0090FF]")}> RecNet </p>
+          <p tw={cn("text-[32px] text-[#0090FF]")}> RecNet </p>
         </div>
         <div tw={cn("flex flex-row justify-between")}>
           <div tw={cn("flex flex-col gap-y-2", "w-[65%]")}>
-            <p>
+            <p tw="inline-block align-bottom">
               {user?.displayName}{" "}
-              <span tw="text-gray-600 mx-1 text-[32px]">(@{user.handle})</span>
+              <span tw="text-gray-600 mx-3 text-[36px] my-auto">
+                (@{user.handle})
+              </span>
             </p>
             <div tw="whitespace-pre-line text-[24px] text-gray-600">
               {user.bio}
@@ -65,11 +67,11 @@ export default async function Image({
           {/* eslint-disable-next-line */}
           <img
             src={user?.photoUrl ?? "https://imgur.com/jVp1pG1.png"}
-            tw="w-[120px] h-[120px] rounded-full mx-8"
+            tw="w-[150px] h-[150px] rounded-full mx-8"
             alt={"User Profile Picture"}
           />
         </div>
-        <p tw="text-[18px] text-gray-500">
+        <p tw="text-[24px] text-gray-500">
           <span>
             {user.numFollowers} follower{user.numFollowers > 1 ? "s" : ""}
           </span>

--- a/apps/recnet/src/app/opengraph-image.tsx
+++ b/apps/recnet/src/app/opengraph-image.tsx
@@ -5,8 +5,8 @@ import { cn } from "@recnet/recnet-web/utils/cn";
 // Image metadata
 export const alt = "RecNet";
 export const size = {
-  width: 1200,
-  height: 630,
+  width: 1600,
+  height: 900,
 };
 
 export const contentType = "image/png";

--- a/apps/recnet/src/app/rec/[id]/opengraph-image.tsx
+++ b/apps/recnet/src/app/rec/[id]/opengraph-image.tsx
@@ -8,8 +8,8 @@ import { formatDate } from "@recnet/recnet-date-fns";
 // Image metadata
 export const alt = "RecNet Recommendation";
 export const size = {
-  width: 1200,
-  height: 630,
+  width: 1600,
+  height: 900,
 };
 
 export const contentType = "image/png";
@@ -44,11 +44,11 @@ export default async function Image({ params }: { params: { id: string } }) {
             tw="w-10 h-10 mr-4"
             alt={"recnet-logo"}
           />
-          <p tw={cn("text-[24px] text-[#0090FF]")}> RecNet </p>
+          <p tw={cn("text-[32px] text-[#0090FF]")}> RecNet </p>
         </div>
         <div tw="font-medium">{rec.article.title}</div>
-        <p tw="text-[24px] text-gray-700">{rec.description} </p>
-        <p tw={cn("text-[18px] text-gray-600")}>{rec.article.author} </p>
+        <p tw="text-[28px] text-gray-700">{rec.description} </p>
+        <p tw={cn("text-[24px] text-gray-600")}>{rec.article.author} </p>
         <div
           tw={cn(
             "flex flex-row items-center",

--- a/apps/recnet/src/app/rec/[id]/page.tsx
+++ b/apps/recnet/src/app/rec/[id]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({
 
   return {
     title: rec.article.title,
-    description: rec.description,
+    description: `${rec.user.displayName} recommends ${rec.description}`,
   };
 }
 

--- a/apps/recnet/src/app/rec/[id]/page.tsx
+++ b/apps/recnet/src/app/rec/[id]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({
 
   return {
     title: rec.article.title,
-    description: `${rec.user.displayName} recommends ${rec.description}`,
+    description: `${rec.user.displayName} recommends: ${rec.description}`,
   };
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Increase OG image size
- Fix rec page metadata desc

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #342 

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->
- OG image size should be bigger (This is a little bit hard to test, sometimes it works in slack, sometimes it doesn't. I am guessing maybe it's related to slack's cache. But even if I cleared cache, still unstable. Anyway, I can confirm it's def bigger by inspecting in html <head>. The size is correct in below image)

![Screenshot 2024-10-25 at 11 30 22 PM](https://github.com/user-attachments/assets/b2c0d97b-65a2-4492-854d-738cdfb16175)

- Rec page's desc should be "{username} recommends: ${desc}"


## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [x] Update the documentation `recnet-docs` if needed
