### PR TITLE
[recnet-api] Add user subscriptions api

### DIFF
--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -54,6 +54,7 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
 });
 
 export type User = Prisma.UserGetPayload<typeof user>;
+export type Subscriptions = Prisma.UserGetPayload<typeof user>["subscriptions"];
 
 export type UserFilterBy = {
   handle?: string;

--- a/apps/recnet-api/src/modules/user/entities/user.subscription.entity.ts
+++ b/apps/recnet-api/src/modules/user/entities/user.subscription.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Channel, SubscriptionType } from "@prisma/client";
+
+export class Subscription {
+  @ApiProperty()
+  type: SubscriptionType;
+
+  @ApiProperty()
+  channels: Channel[];
+}

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -35,6 +35,7 @@ import {
   patchUserMeRequestSchema,
   postUserFollowRequestSchema,
   postUserMeRequestSchema,
+  postUsersSubscriptionsRequestSchema,
   postUserValidateHandleRequestSchema,
   postUserValidateInviteCodeRequestSchema,
 } from "@recnet/recnet-api-model";
@@ -47,10 +48,12 @@ import {
   ValidateUserHandleDto,
   ValidateUserInviteCodeDto,
 } from "./dto/validate.user.dto";
+import { Subscription } from "./entities/user.subscription.entity";
 import {
   GetSubscriptionsResponse,
   GetUserMeResponse,
   GetUsersResponse,
+  PostSubscriptionsResponse,
 } from "./user.response";
 import { UserService } from "./user.service";
 
@@ -225,6 +228,10 @@ export class UserController {
     return this.userService.unfollowUser(userId, dto.userId);
   }
 
+  @ApiOperation({
+    summary: "Get subscriptions",
+    description: "Get the current user's subscriptions.",
+  })
   @Get("subscriptions")
   @ApiBearerAuth()
   @Auth()
@@ -233,5 +240,22 @@ export class UserController {
   ): Promise<GetSubscriptionsResponse> {
     const { userId } = authUser;
     return this.userService.getSubscriptions(userId);
+  }
+
+  @ApiOperation({
+    summary: "Create or update subscription",
+    description: "Create or update the current user's subscription.",
+  })
+  @Post("subscriptions")
+  @ApiBearerAuth()
+  @UsePipes(new ZodValidationBodyPipe(postUsersSubscriptionsRequestSchema))
+  @Auth()
+  public async createOrUpdateSubscription(
+    @User() authUser: AuthUser,
+    @Body() dto: Subscription
+  ): Promise<PostSubscriptionsResponse> {
+    const { userId } = authUser;
+    const { type, channels } = dto;
+    return this.userService.createOrUpdateSubscription(userId, type, channels);
   }
 }

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -47,7 +47,11 @@ import {
   ValidateUserHandleDto,
   ValidateUserInviteCodeDto,
 } from "./dto/validate.user.dto";
-import { GetUserMeResponse, GetUsersResponse } from "./user.response";
+import {
+  GetSubscriptionsResponse,
+  GetUserMeResponse,
+  GetUsersResponse,
+} from "./user.response";
 import { UserService } from "./user.service";
 
 @ApiTags("users")
@@ -219,5 +223,15 @@ export class UserController {
   ): Promise<void> {
     const { userId } = authUser;
     return this.userService.unfollowUser(userId, dto.userId);
+  }
+
+  @Get("subscriptions")
+  @ApiBearerAuth()
+  @Auth()
+  public async getSubscriptions(
+    @User() authUser: AuthUser
+  ): Promise<GetSubscriptionsResponse> {
+    const { userId } = authUser;
+    return this.userService.getSubscriptions(userId);
   }
 }

--- a/apps/recnet-api/src/modules/user/user.response.ts
+++ b/apps/recnet-api/src/modules/user/user.response.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from "@nestjs/swagger";
 
 import { User } from "./entities/user.entity";
 import { UserPreview } from "./entities/user.preview.entity";
+import { Subscription } from "./entities/user.subscription.entity";
 
 export class GetUsersResponse {
   @ApiProperty()
@@ -14,4 +15,9 @@ export class GetUsersResponse {
 export class GetUserMeResponse {
   @ApiProperty()
   user: User;
+}
+
+export class GetSubscriptionsResponse {
+  @ApiProperty()
+  subscriptions: Subscription[];
 }

--- a/apps/recnet-api/src/modules/user/user.response.ts
+++ b/apps/recnet-api/src/modules/user/user.response.ts
@@ -21,3 +21,8 @@ export class GetSubscriptionsResponse {
   @ApiProperty()
   subscriptions: Subscription[];
 }
+
+export class PostSubscriptionsResponse {
+  @ApiProperty()
+  subscription: Subscription;
+}

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -23,7 +23,11 @@ import { UpdateUserDto } from "./dto/update.user.dto";
 import { User } from "./entities/user.entity";
 import { UserPreview } from "./entities/user.preview.entity";
 import { Subscription } from "./entities/user.subscription.entity";
-import { GetSubscriptionsResponse, GetUsersResponse } from "./user.response";
+import {
+  GetSubscriptionsResponse,
+  GetUsersResponse,
+  PostSubscriptionsResponse,
+} from "./user.response";
 import { transformUserPreview } from "./user.transformer";
 
 @Injectable()
@@ -173,6 +177,32 @@ export class UserService {
     const user = await this.userRepository.findUserById(userId);
     return {
       subscriptions: this.transformSubscriptions(user.subscriptions),
+    };
+  }
+
+  public async createOrUpdateSubscription(
+    userId: string,
+    type: SubscriptionType,
+    channels: Channel[]
+  ): Promise<PostSubscriptionsResponse> {
+    if (type === SubscriptionType.WEEKLY_DIGEST && channels.length === 0) {
+      throw new RecnetError(
+        ErrorCode.INVALID_SUBSCRIPTION,
+        HttpStatus.BAD_REQUEST,
+        "Weekly digest subscription must have at least one channel."
+      );
+    }
+
+    const subscriptions = await this.userRepository.createOrUpdateSubscription(
+      userId,
+      type,
+      channels
+    );
+    return {
+      subscription: {
+        type,
+        channels: subscriptions.map((s) => s.channel),
+      },
     };
   }
 

--- a/apps/recnet-api/src/utils/error/recnet.error.const.ts
+++ b/apps/recnet-api/src/utils/error/recnet.error.const.ts
@@ -10,6 +10,7 @@ export const ErrorCode = {
   ACCOUNT_NOT_ACTIVATED: 1008,
   DIGITAL_LIBRARY_RANK_CONFLICT: 1009,
   INVALID_REACTION_TYPE: 1010,
+  INVALID_SUBSCRIPTION: 1011,
 
   // DB error codes
   DB_UNKNOWN_ERROR: 2000,
@@ -37,6 +38,7 @@ export const errorMessages = {
   [ErrorCode.DIGITAL_LIBRARY_RANK_CONFLICT]:
     "Digital library rank must be unique",
   [ErrorCode.INVALID_REACTION_TYPE]: "Invalid reaction type",
+  [ErrorCode.INVALID_SUBSCRIPTION]: "Invalid subscription",
   [ErrorCode.DB_UNKNOWN_ERROR]: "Database error",
   [ErrorCode.DB_USER_NOT_FOUND]: "User not found",
   [ErrorCode.DB_UNIQUE_CONSTRAINT]: "Unique constraint violation",

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { userPreviewSchema, userSchema } from "../model";
+import { subscriptionSchema, userPreviewSchema, userSchema } from "../model";
 
 // GET /users
 export const getUsersParamsSchema = z.object({
@@ -108,4 +108,18 @@ export const deleteUserFollowParamsSchema = z.object({
 });
 export type DeleteUserFollowParams = z.infer<
   typeof deleteUserFollowParamsSchema
+>;
+
+// GET /users/subscriptions
+export const getUsersSubscriptionsResponseSchema = z.object({
+  subscriptions: z.array(subscriptionSchema),
+});
+export type GetUsersSubscriptionsResponse = z.infer<
+  typeof getUsersSubscriptionsResponseSchema
+>;
+
+// POST /users/subscriptions
+export const postUsersSubscriptionsRequestSchema = subscriptionSchema;
+export type PostUsersSubscriptionsRequest = z.infer<
+  typeof postUsersSubscriptionsRequestSchema
 >;

--- a/libs/recnet-api-model/src/lib/model.ts
+++ b/libs/recnet-api-model/src/lib/model.ts
@@ -106,3 +106,9 @@ export const digitalLibrarySchema = z.object({
   isVerified: z.boolean(),
 });
 export type DigitalLibrary = z.infer<typeof digitalLibrarySchema>;
+
+export const subscriptionSchema = z.object({
+  type: z.enum(["WEEKLY_DIGEST"]),
+  channels: z.array(z.enum(["EMAIL", "SLACK"])),
+});
+export type Subscription = z.infer<typeof subscriptionSchema>;


### PR DESCRIPTION
## Description

Add user subscriptions api
- `GET /users/subscriptions`
- `POST /users/subscriptions`

## Related Issue

- https://github.com/lil-lab/recnet/issues/260

## Notes

Design doc: https://www.notion.so/Multiple-Distributing-Channels-Slack-Integration-61323d4345c547cb869129e117c5d722

## Test

<!--- Please describe in detail how you tested your changes locally. -->
1. Run server locally
2. Hit the two new apis with your Auth token

## Screenshots (if appropriate):
<img width="889" alt="Screenshot 2024-11-07 at 9 26 07 PM" src="https://github.com/user-attachments/assets/d48b5fe6-aa86-4475-8958-954201ad203d">
<img width="877" alt="Screenshot 2024-11-07 at 9 25 39 PM" src="https://github.com/user-attachments/assets/4205bd9a-a19e-486e-8453-1fbbd879f6ce">

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
