### PR TITLE
[recnet-api] Follow the person who invites the user

### DIFF
--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -107,11 +107,19 @@ export default class UserRepository {
         select: user.select,
       });
 
-      await prisma.inviteCode.update({
+      const inviteCode = await prisma.inviteCode.update({
         where: { code: createUserInput.inviteCode },
         data: {
           usedById: userInTransaction.id,
           usedAt: new Date(),
+        },
+      });
+
+      // follow the person who gave the invite code
+      await this.prisma.followingRecord.create({
+        data: {
+          followedById: userInTransaction.id,
+          followingId: inviteCode.ownerId,
         },
       });
 

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -116,7 +116,7 @@ export default class UserRepository {
       });
 
       // follow the person who gave the invite code
-      await this.prisma.followingRecord.create({
+      await prisma.followingRecord.create({
         data: {
           followedById: userInTransaction.id,
           followingId: inviteCode.ownerId,


### PR DESCRIPTION
## Description

Follow the person who invites the user when creating an account

## Related Issue

- https://github.com/lil-lab/recnet/issues/356

## Notes

<!-- Other thing to say -->
N/A

## Test

1. Run local server
2. Create a user by hitting `POST /users/me`
3. Check if there is a following record that followerId = userId and followingId = inviterId

## Screenshots (if appropriate):

TBA

## TODO

- [x] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
