### PR TITLE
[recnet-api] Slack oauth API

### DIFF
--- a/apps/recnet-api/prisma/migrations/20241124232108_add_slack_oauth/down.sql
+++ b/apps/recnet-api/prisma/migrations/20241124232108_add_slack_oauth/down.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "slackAccessToken",
+DROP COLUMN "slackUserId",
+DROP COLUMN "slackWorkspaceName",
+ADD COLUMN     "slackEmail" VARCHAR(128);
+

--- a/apps/recnet-api/prisma/migrations/20241124232108_add_slack_oauth/migration.sql
+++ b/apps/recnet-api/prisma/migrations/20241124232108_add_slack_oauth/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `slackEmail` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "slackEmail",
+ADD COLUMN     "slackAccessToken" VARCHAR(128),
+ADD COLUMN     "slackUserId" VARCHAR(64),
+ADD COLUMN     "slackWorkspaceName" VARCHAR(64);

--- a/apps/recnet-api/prisma/schema.prisma
+++ b/apps/recnet-api/prisma/schema.prisma
@@ -76,7 +76,9 @@ model User {
   lastLoginAt         DateTime
   role                Role     @default(USER) // Enum type
   isActivated         Boolean  @default(true)
-  slackEmail          String?  @db.VarChar(128)
+  slackUserId         String?  @db.VarChar(64)
+  slackAccessToken    String?  @db.VarChar(128)
+  slackWorkspaceName  String?  @db.VarChar(64)
   createdAt           DateTime @default(now())
   updatedAt           DateTime @default(now()) @updatedAt
 

--- a/apps/recnet-api/src/config/common.config.ts
+++ b/apps/recnet-api/src/config/common.config.ts
@@ -33,6 +33,7 @@ export const NodemailerConfig = registerAs("nodemailer", () => ({
 }));
 
 export const SlackConfig = registerAs("slack", () => ({
+  token: parsedEnv.SLACK_TOKEN, // to be deprecated
   clientId: parsedEnv.SLACK_CLIENT_ID,
   clientSecret: parsedEnv.SLACK_CLIENT_SECRET,
 }));

--- a/apps/recnet-api/src/config/common.config.ts
+++ b/apps/recnet-api/src/config/common.config.ts
@@ -33,5 +33,6 @@ export const NodemailerConfig = registerAs("nodemailer", () => ({
 }));
 
 export const SlackConfig = registerAs("slack", () => ({
-  token: parsedEnv.SLACK_TOKEN,
+  clientId: parsedEnv.SLACK_CLIENT_ID,
+  clientSecret: parsedEnv.SLACK_CLIENT_SECRET,
 }));

--- a/apps/recnet-api/src/config/common.config.ts
+++ b/apps/recnet-api/src/config/common.config.ts
@@ -33,7 +33,8 @@ export const NodemailerConfig = registerAs("nodemailer", () => ({
 }));
 
 export const SlackConfig = registerAs("slack", () => ({
-  token: parsedEnv.SLACK_TOKEN, // to be deprecated
+  token: parsedEnv.SLACK_TOKEN, // to be de
   clientId: parsedEnv.SLACK_CLIENT_ID,
   clientSecret: parsedEnv.SLACK_CLIENT_SECRET,
+  tokenEncryptionKey: parsedEnv.SLACK_TOKEN_ENCRYPTION_KEY,
 }));

--- a/apps/recnet-api/src/config/env.schema.ts
+++ b/apps/recnet-api/src/config/env.schema.ts
@@ -25,6 +25,8 @@ export const EnvSchema = z.object({
   SMTP_PASS: z.string(),
   // slack config
   SLACK_TOKEN: z.string().optional(),
+  SLACK_CLIENT_ID: z.string(),
+  SLACK_CLIENT_SECRET: z.string(),
 });
 
 export const parseEnv = (env: Record<string, string | undefined>) => {

--- a/apps/recnet-api/src/config/env.schema.ts
+++ b/apps/recnet-api/src/config/env.schema.ts
@@ -27,6 +27,9 @@ export const EnvSchema = z.object({
   SLACK_TOKEN: z.string().optional(),
   SLACK_CLIENT_ID: z.string(),
   SLACK_CLIENT_SECRET: z.string(),
+  SLACK_TOKEN_ENCRYPTION_KEY: z
+    .string()
+    .transform((val) => Buffer.from(val, "base64")),
 });
 
 export const parseEnv = (env: Record<string, string | undefined>) => {

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -182,6 +182,32 @@ export default class UserRepository {
     });
   }
 
+  public async findUserSlackInfo(userId: string): Promise<{
+    slackUserId: string | null;
+    slackWorkspaceName: string | null;
+    slackAccessToken: string | null;
+  }> {
+    return this.prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: {
+        slackUserId: true,
+        slackWorkspaceName: true,
+        slackAccessToken: true,
+      },
+    });
+  }
+
+  public async deleteSlackInfo(userId: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        slackUserId: null,
+        slackWorkspaceName: null,
+        slackAccessToken: null,
+      },
+    });
+  }
+
   private transformUserFilterByToPrismaWhere(
     filter: UserFilterBy
   ): Prisma.UserWhereInput {

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -182,21 +182,6 @@ export default class UserRepository {
     });
   }
 
-  public async findUserSlackInfo(userId: string): Promise<{
-    slackUserId: string | null;
-    slackWorkspaceName: string | null;
-    slackAccessToken: string | null;
-  }> {
-    return this.prisma.user.findUniqueOrThrow({
-      where: { id: userId },
-      select: {
-        slackUserId: true,
-        slackWorkspaceName: true,
-        slackAccessToken: true,
-      },
-    });
-  }
-
   public async updateUserSlackInfo(
     userId: string,
     slackOauthInfo: {

--- a/apps/recnet-api/src/database/repository/user.repository.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.ts
@@ -197,6 +197,20 @@ export default class UserRepository {
     });
   }
 
+  public async updateUserSlackInfo(
+    userId: string,
+    slackOauthInfo: {
+      slackUserId: string;
+      slackWorkspaceName: string;
+      slackAccessToken: string;
+    }
+  ): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: slackOauthInfo,
+    });
+  }
+
   public async deleteSlackInfo(userId: string): Promise<void> {
     await this.prisma.user.update({
       where: { id: userId },

--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -40,7 +40,6 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
       },
     },
     email: true,
-    slackEmail: true,
     role: true,
     isActivated: true,
     following: {

--- a/apps/recnet-api/src/database/repository/user.repository.type.ts
+++ b/apps/recnet-api/src/database/repository/user.repository.type.ts
@@ -49,6 +49,9 @@ export const user = Prisma.validator<Prisma.UserDefaultArgs>()({
     },
     recommendations: true,
     subscriptions: true,
+    slackUserId: true,
+    slackWorkspaceName: true,
+    slackAccessToken: true,
   },
 });
 

--- a/apps/recnet-api/src/modules/slack/slack.service.ts
+++ b/apps/recnet-api/src/modules/slack/slack.service.ts
@@ -43,6 +43,7 @@ export class SlackService {
       );
       result = await this.transporter.sendDirectMessage(
         user,
+        user.slackAccessToken || "", // TODO: pass decrypted access token
         weeklyDigest.messageBlocks,
         weeklyDigest.notificationText
       );

--- a/apps/recnet-api/src/modules/slack/slack.service.ts
+++ b/apps/recnet-api/src/modules/slack/slack.service.ts
@@ -1,11 +1,13 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { HttpStatus, Inject, Injectable } from "@nestjs/common";
 import { ConfigType } from "@nestjs/config";
 
 import { AppConfig } from "@recnet-api/config/common.config";
 import { User as DbUser } from "@recnet-api/database/repository/user.repository.type";
 import { WeeklyDigestContent } from "@recnet-api/modules/subscription/subscription.type";
+import { RecnetError } from "@recnet-api/utils/error/recnet.error";
+import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
 
-import { SendSlackResult } from "./slack.type";
+import { SendSlackResult, SlackOauthInfo } from "./slack.type";
 import { weeklyDigestSlackTemplate } from "./templates/weekly-digest.template";
 import { SlackTransporter } from "./transporters/slack.transporter";
 
@@ -16,6 +18,16 @@ export class SlackService {
     private readonly appConfig: ConfigType<typeof AppConfig>,
     private readonly transporter: SlackTransporter
   ) {}
+
+  public async installApp(
+    userId: string,
+    code: string
+  ): Promise<SlackOauthInfo> {
+    const slackOauthInfo = await this.transporter.accessOauthInfo(userId, code);
+    await this.validateSlackOauthInfo(userId, slackOauthInfo);
+    // Todo: encrypt access token
+    return slackOauthInfo;
+  }
 
   public async sendWeeklyDigest(
     user: DbUser,
@@ -39,5 +51,26 @@ export class SlackService {
     }
 
     return result;
+  }
+
+  private async validateSlackOauthInfo(
+    userId: string,
+    slackOauthInfo: SlackOauthInfo
+  ): Promise<void> {
+    let errorMsg = "";
+    if (slackOauthInfo.slackAccessToken === "") {
+      errorMsg = "Failed to get access token, userId: " + userId;
+    } else if (slackOauthInfo.slackUserId === "") {
+      errorMsg = "Failed to get user id, userId: " + userId;
+    } else if (slackOauthInfo.slackWorkspaceName === "") {
+      errorMsg = "Failed to get workspace name, userId: " + userId;
+    }
+    if (errorMsg !== "") {
+      throw new RecnetError(
+        ErrorCode.SLACK_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        `Failed to get workspace name`
+      );
+    }
   }
 }

--- a/apps/recnet-api/src/modules/slack/slack.type.ts
+++ b/apps/recnet-api/src/modules/slack/slack.type.ts
@@ -7,3 +7,9 @@ export type SendSlackResult = {
 };
 
 export type SlackMessageBlocks = Readonly<SlackBlockDto>[];
+
+export type SlackOauthInfo = {
+  slackAccessToken: string;
+  slackUserId: string;
+  slackWorkspaceName: string;
+};

--- a/apps/recnet-api/src/modules/slack/transporters/slack.transporter.ts
+++ b/apps/recnet-api/src/modules/slack/transporters/slack.transporter.ts
@@ -108,7 +108,10 @@ export class SlackTransporter {
 
   private async getUserSlackId(user: DbUser): Promise<string> {
     const email = user.email;
-    const userResp = await this.client.users.lookupByEmail({ email });
+    const userResp = await this.client.users.lookupByEmail({
+      email,
+      token: this.slackConfig.token,
+    });
     const slackId = userResp?.user?.id;
     if (!slackId) {
       throw new RecnetError(
@@ -128,6 +131,7 @@ export class SlackTransporter {
     // Open a direct message conversation
     const conversationResp = await this.client.conversations.open({
       users: userSlackId,
+      token: this.slackConfig.token,
     });
     const conversationId = conversationResp?.channel?.id;
     if (!conversationId) {
@@ -143,6 +147,7 @@ export class SlackTransporter {
       channel: conversationId,
       text: notificationText,
       blocks: message,
+      token: this.slackConfig.token,
     });
   }
 }

--- a/apps/recnet-api/src/modules/subscription/subscription.controller.ts
+++ b/apps/recnet-api/src/modules/subscription/subscription.controller.ts
@@ -33,7 +33,7 @@ export class SubscriptionController {
 
   /* Development only */
   @ApiOperation({
-    summary: "Send weekly digest slack to the designated user.",
+    summary: "[Dev only] Send weekly digest slack to the designated user.",
     description: "This endpoint is for development only.",
   })
   @ApiCreatedResponse()

--- a/apps/recnet-api/src/modules/subscription/subscription.controller.ts
+++ b/apps/recnet-api/src/modules/subscription/subscription.controller.ts
@@ -1,0 +1,90 @@
+import { generateMock } from "@anatine/zod-mock";
+import { Body, Controller, HttpStatus, Inject, Post } from "@nestjs/common";
+import { ConfigType } from "@nestjs/config";
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger";
+
+import { AppConfig } from "@recnet-api/config/common.config";
+import UserRepository from "@recnet-api/database/repository/user.repository";
+import { RecnetError } from "@recnet-api/utils/error/recnet.error";
+import { ErrorCode } from "@recnet-api/utils/error/recnet.error.const";
+
+import { getLatestCutOff } from "@recnet/recnet-date-fns";
+
+import { announcementSchema, recSchema } from "@recnet/recnet-api-model";
+
+import { WeeklyDigestContent } from "./subscription.type";
+
+import { SlackService } from "../slack/slack.service";
+
+@ApiTags("subscriptions")
+@Controller("subscriptions")
+export class SubscriptionController {
+  constructor(
+    @Inject(AppConfig.KEY)
+    private readonly appConfig: ConfigType<typeof AppConfig>,
+    private readonly slackService: SlackService,
+    private readonly userRepository: UserRepository
+  ) {}
+
+  /* Development only */
+  @ApiOperation({
+    summary: "Send weekly digest slack to the designated user.",
+    description: "This endpoint is for development only.",
+  })
+  @ApiCreatedResponse()
+  @ApiBody({
+    schema: {
+      properties: {
+        userId: { type: "string" },
+      },
+      required: ["userId"],
+    },
+  })
+  @Post("slack/test")
+  public async testSendingWeeklyDigest(
+    @Body("userId") userId: string
+  ): Promise<void> {
+    if (this.appConfig.nodeEnv === "production") {
+      throw new RecnetError(
+        ErrorCode.INTERNAL_SERVER_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "This endpoint is only for development"
+      );
+    }
+
+    function getMockWeeklyDigestData(): WeeklyDigestContent {
+      const getMockRec = (title = 1) =>
+        generateMock(recSchema, {
+          stringMap: {
+            photoUrl: () => "https://avatar.iran.liara.run/public",
+            title: () => `Paper Title ${title}`,
+          },
+        });
+      const announcement = generateMock(announcementSchema, {
+        stringMap: {
+          content: () => "This is a test announcement!",
+        },
+      });
+      return {
+        recs: [getMockRec(), getMockRec(2), getMockRec(3), getMockRec()],
+        numUnusedInviteCodes: 3,
+        latestAnnouncement: {
+          ...announcement,
+          startAt: new Date(announcement.startAt),
+          endAt: new Date(announcement.endAt),
+        },
+      };
+    }
+
+    const cutoff = getLatestCutOff();
+    const user = await this.userRepository.findUserById(userId);
+    const content = getMockWeeklyDigestData();
+
+    this.slackService.sendWeeklyDigest(user, content, cutoff);
+  }
+}

--- a/apps/recnet-api/src/modules/subscription/subscription.module.ts
+++ b/apps/recnet-api/src/modules/subscription/subscription.module.ts
@@ -2,12 +2,13 @@ import { Module } from "@nestjs/common";
 
 import { DbRepositoryModule } from "@recnet-api/database/repository/db.repository.module";
 import { EmailModule } from "@recnet-api/modules/email/email.module";
+import { SlackModule } from "@recnet-api/modules/slack/slack.module";
 
+import { SubscriptionController } from "./subscription.controller";
 import { WeeklyDigestWorker } from "./weekly-digest.worker";
 
-import { SlackModule } from "../slack/slack.module";
-
 @Module({
+  controllers: [SubscriptionController],
   providers: [WeeklyDigestWorker],
   imports: [DbRepositoryModule, EmailModule, SlackModule],
 })

--- a/apps/recnet-api/src/modules/user/dto/slack-oauth.user.dto.ts
+++ b/apps/recnet-api/src/modules/user/dto/slack-oauth.user.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SlackOauthDto {
+  @ApiProperty({
+    description: "The code from Slack OAuth.",
+    example:
+      "7917990338740.8077326386099.68f91412920cf8158cbb632a208afe42b29b5740c16e7829425d8db824def004",
+  })
+  code: string;
+}

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -36,6 +36,7 @@ import {
   postUserFollowRequestSchema,
   postUserMeRequestSchema,
   postUsersSubscriptionsRequestSchema,
+  PostUsersSubscriptionsSlackOauthRequest,
   postUserValidateHandleRequestSchema,
   postUserValidateInviteCodeRequestSchema,
 } from "@recnet/recnet-api-model";
@@ -50,6 +51,7 @@ import {
 } from "./dto/validate.user.dto";
 import { Subscription } from "./entities/user.subscription.entity";
 import {
+  GetSlackOauthInfoResponse,
   GetSubscriptionsResponse,
   GetUserMeResponse,
   GetUsersResponse,
@@ -257,5 +259,46 @@ export class UserController {
     const { userId } = authUser;
     const { type, channels } = dto;
     return this.userService.createOrUpdateSubscription(userId, type, channels);
+  }
+
+  @ApiOperation({
+    summary: "Get Slack OAuth info",
+    description: "Get the current user's Slack OAuth info.",
+  })
+  @Get("subscriptions/slack/oauth")
+  @ApiBearerAuth()
+  @Auth()
+  public async getSlackOauthInfo(
+    @User() authUser: AuthUser
+  ): Promise<GetSlackOauthInfoResponse> {
+    const { userId } = authUser;
+    return this.userService.getSlackOauthInfo(userId);
+  }
+
+  @ApiOperation({
+    summary: "Slack OAuth",
+    description: "Slack OAuth",
+  })
+  @Post("subscriptions/slack/oauth")
+  @ApiBearerAuth()
+  @Auth()
+  public async slackOauth(
+    @User() authUser: AuthUser,
+    @Body() dto: PostUsersSubscriptionsSlackOauthRequest
+  ): Promise<GetSlackOauthInfoResponse> {
+    const { userId } = authUser;
+    return this.userService.installSlack(userId, dto.code);
+  }
+
+  @ApiOperation({
+    summary: "Delete Slack OAuth",
+    description: "Delete Slack OAuth",
+  })
+  @Delete("subscriptions/slack/oauth")
+  @ApiBearerAuth()
+  @Auth()
+  public async deleteSlackOauth(@User() authUser: AuthUser): Promise<void> {
+    const { userId } = authUser;
+    return this.userService.deleteSlack(userId);
   }
 }

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -36,7 +36,6 @@ import {
   postUserFollowRequestSchema,
   postUserMeRequestSchema,
   postUsersSubscriptionsRequestSchema,
-  PostUsersSubscriptionsSlackOauthRequest,
   postUserValidateHandleRequestSchema,
   postUserValidateInviteCodeRequestSchema,
 } from "@recnet/recnet-api-model";
@@ -44,6 +43,7 @@ import {
 import { CreateUserDto } from "./dto/create.user.dto";
 import { FollowUserDto, UnfollowUserDto } from "./dto/follow.user.dto";
 import { QueryUsersDto } from "./dto/query.users.dto";
+import { SlackOauthDto } from "./dto/slack-oauth.user.dto";
 import { UpdateUserActivateDto, UpdateUserDto } from "./dto/update.user.dto";
 import {
   ValidateUserHandleDto,
@@ -284,7 +284,7 @@ export class UserController {
   @Auth()
   public async slackOauth(
     @User() authUser: AuthUser,
-    @Body() dto: PostUsersSubscriptionsSlackOauthRequest
+    @Body() dto: SlackOauthDto
   ): Promise<GetSlackOauthInfoResponse> {
     const { userId } = authUser;
     return this.userService.installSlack(userId, dto.code);

--- a/apps/recnet-api/src/modules/user/user.module.ts
+++ b/apps/recnet-api/src/modules/user/user.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 
 import { DbRepositoryModule } from "@recnet-api/database/repository/db.repository.module";
+import { SlackModule } from "@recnet-api/modules/slack/slack.module";
 
 import { UserController } from "./user.controller";
 import { UserService } from "./user.service";
@@ -8,6 +9,6 @@ import { UserService } from "./user.service";
 @Module({
   controllers: [UserController],
   providers: [UserService],
-  imports: [DbRepositoryModule],
+  imports: [DbRepositoryModule, SlackModule],
 })
 export class UserModule {}

--- a/apps/recnet-api/src/modules/user/user.response.ts
+++ b/apps/recnet-api/src/modules/user/user.response.ts
@@ -26,3 +26,8 @@ export class PostSubscriptionsResponse {
   @ApiProperty()
   subscription: Subscription;
 }
+
+export class GetSlackOauthInfoResponse {
+  @ApiProperty()
+  workspaceName: string | null;
+}

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -223,8 +223,15 @@ export class UserService {
     userId: string,
     code: string
   ): Promise<GetSlackOauthInfoResponse> {
-    // TODO: installSlackOauth
+    const user = await this.userRepository.findUserSlackInfo(userId);
+    if (user.slackUserId) {
+      throw new RecnetError(
+        ErrorCode.SLACK_ALREADY_INSTALLED,
+        HttpStatus.BAD_REQUEST
+      );
+    }
     const oauthInfo = await this.slackService.installApp(userId, code);
+    await this.userRepository.updateUserSlackInfo(userId, oauthInfo);
     return {
       workspaceName: oauthInfo.slackWorkspaceName,
     };

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -213,7 +213,7 @@ export class UserService {
   public async getSlackOauthInfo(
     userId: string
   ): Promise<GetSlackOauthInfoResponse> {
-    const user = await this.userRepository.findUserSlackInfo(userId);
+    const user = await this.userRepository.findUserById(userId);
     return {
       workspaceName: user.slackWorkspaceName,
     };
@@ -223,7 +223,7 @@ export class UserService {
     userId: string,
     code: string
   ): Promise<GetSlackOauthInfoResponse> {
-    const user = await this.userRepository.findUserSlackInfo(userId);
+    const user = await this.userRepository.findUserById(userId);
     if (user.slackUserId) {
       throw new RecnetError(
         ErrorCode.SLACK_ALREADY_INSTALLED,

--- a/apps/recnet-api/src/utils/error/recnet.error.const.ts
+++ b/apps/recnet-api/src/utils/error/recnet.error.const.ts
@@ -11,6 +11,7 @@ export const ErrorCode = {
   DIGITAL_LIBRARY_RANK_CONFLICT: 1009,
   INVALID_REACTION_TYPE: 1010,
   INVALID_SUBSCRIPTION: 1011,
+  SLACK_ALREADY_INSTALLED: 1012,
 
   // DB error codes
   DB_UNKNOWN_ERROR: 2000,
@@ -39,6 +40,7 @@ export const errorMessages = {
     "Digital library rank must be unique",
   [ErrorCode.INVALID_REACTION_TYPE]: "Invalid reaction type",
   [ErrorCode.INVALID_SUBSCRIPTION]: "Invalid subscription",
+  [ErrorCode.SLACK_ALREADY_INSTALLED]: "Slack already installed",
   [ErrorCode.DB_UNKNOWN_ERROR]: "Database error",
   [ErrorCode.DB_USER_NOT_FOUND]: "User not found",
   [ErrorCode.DB_UNIQUE_CONSTRAINT]: "Unique constraint violation",
@@ -46,4 +48,5 @@ export const errorMessages = {
   [ErrorCode.EMAIL_SEND_ERROR]: "Email send error",
   [ErrorCode.FETCH_DIGITAL_LIBRARY_ERROR]: "Fetch digital library error",
   [ErrorCode.SLACK_ERROR]: "Slack error",
+  [ErrorCode.SLACK_ALREADY_INSTALLED]: "Slack already installed",
 };

--- a/apps/recnet-api/src/utils/index.ts
+++ b/apps/recnet-api/src/utils/index.ts
@@ -1,5 +1,27 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+
 export const getOffset = (page: number, pageSize: number): number =>
   (page - 1) * pageSize;
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+export const encrypt = (data: string, key: Buffer): string => {
+  const iv = randomBytes(16);
+  const cipher = createCipheriv("aes-256-cbc", key, iv);
+  let encrypted = cipher.update(data, "utf8", "base64");
+  encrypted += cipher.final("base64");
+  return `${iv.toString("base64")}:${encrypted}`;
+};
+
+export const decrypt = (data: string, key: Buffer): string => {
+  const [iv, encrypted] = data.split(":");
+  const decipher = createDecipheriv(
+    "aes-256-cbc",
+    key,
+    Buffer.from(iv, "base64")
+  );
+  let decrypted = decipher.update(encrypted, "base64", "utf8");
+  decrypted += decipher.final("utf8");
+  return decrypted;
+};

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -130,3 +130,19 @@ export const postUsersSubscriptionsResponseSchema = z.object({
 export type PostUsersSubscriptionsResponse = z.infer<
   typeof postUsersSubscriptionsResponseSchema
 >;
+
+// POST /users/subscriptions/slack/oauth
+export const postUsersSubscriptionsSlackOauthRequestSchema = z.object({
+  code: z.string(),
+});
+export type PostUsersSubscriptionsSlackOauthRequest = z.infer<
+  typeof postUsersSubscriptionsSlackOauthRequestSchema
+>;
+
+// GET /users/subscriptions/slack/oauth
+export const getUsersSubscriptionsSlackOauthResponseSchema = z.object({
+  workspaceName: z.string().nullable(),
+});
+export type GetUsersSubscriptionsSlackOauthResponse = z.infer<
+  typeof getUsersSubscriptionsSlackOauthResponseSchema
+>;


### PR DESCRIPTION
## Description

This PR is the backend part of migrating slack app to the oath access token, which will resolve the limitation of single workspace.

Doc: https://www.notion.so/Slack-OAuth-flow-14551bd6607c80d08a13f56c04a81abd

What's included in this PR:

1. Add following API endpoints:

- `GET /users/subscriptions/slack/oauth`: ger user's slack workspace name they installed
- `POST /users/subscriptions/slack/oauth`: Post code from FE to slack API to exchange the access token, store information in DB
- `DELETE /users/subscriptions/slack/oauth`: delete the user's slack information

2. Add back slack test API `POST /subscriptions/slack/test`
3. modify SlackTransporter logic to use the user's accessToken when sending messages
4. Add new slack fields and delete slackEmail fields in user table


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Notes

<!-- Other thing to say -->
1. AccessToken is encrypted in the storage and is decrypted before it needs to be used. Encryption key is stored as an environment variable.
2. Backward compatible. If the user has subscribed Slack channel without a user access token, we will use the one in env var.

## Test

<!--- Please describe in detail how you tested your changes locally. -->

1. Run local server
2. Pasting this URL in your browser (fill in the scope and client_id)
`https://slack.com/oauth/v2/authorize?scope={scope}&client_id={client_id}`
<img width="1464" alt="Screenshot 2024-11-24 at 9 24 53 PM" src="https://github.com/user-attachments/assets/c771efc8-4e8c-490c-a984-dc81d20a4ae3">

3. Choose a workspace and click allow button, pull the code in the callback request from devtools
<img width="736" alt="Screenshot 2024-11-24 at 9 26 05 PM" src="https://github.com/user-attachments/assets/b5a9e8fa-c22b-45f9-9d3b-3cf490bd3e53">
4. Use the code to hit `POST /users/subscriptions/slack/oauth`
5. Hit `POST /subscriptions/slack/test` to see if you got the slack message
6. Hit `GET  /users/subscriptions/slack/oauth` and `DELETE  /users/subscriptions/slack/oauth` to see if it works correctly

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->
N/A

## TODO

- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
- [ ] Update environment variables in staging and production env
- [ ] Add unit tests
- [ ] Add migration announcement with specific deadline

