### PR TITLE
fix: send redirect uri to slac Oauth access API

### DIFF
--- a/apps/recnet-api/src/modules/slack/slack.service.ts
+++ b/apps/recnet-api/src/modules/slack/slack.service.ts
@@ -30,9 +30,14 @@ export class SlackService {
 
   public async installApp(
     userId: string,
+    redirectUri: string,
     code: string
   ): Promise<SlackOauthInfo> {
-    const slackOauthInfo = await this.accessOauthInfo(userId, code);
+    const slackOauthInfo = await this.accessOauthInfo(
+      userId,
+      redirectUri,
+      code
+    );
     await this.validateSlackOauthInfo(userId, slackOauthInfo);
 
     // encrypt access token
@@ -73,11 +78,13 @@ export class SlackService {
 
   public async accessOauthInfo(
     userId: string,
+    redirectUri: string,
     code: string
   ): Promise<SlackOauthInfo> {
     const formData = new FormData();
     formData.append("client_id", this.slackConfig.clientId);
     formData.append("client_secret", this.slackConfig.clientSecret);
+    formData.append("redirect_uri", redirectUri);
     formData.append("code", code);
 
     try {

--- a/apps/recnet-api/src/modules/user/dto/slack-oauth.user.dto.ts
+++ b/apps/recnet-api/src/modules/user/dto/slack-oauth.user.dto.ts
@@ -7,4 +7,10 @@ export class SlackOauthDto {
       "7917990338740.8077326386099.68f91412920cf8158cbb632a208afe42b29b5740c16e7829425d8db824def004",
   })
   code: string;
+
+  @ApiProperty({
+    description: "The redirect URI from Slack OAuth.",
+    example: "https://localhost:3000/api/slack/oauth/callback",
+  })
+  redirectUri: string;
 }

--- a/apps/recnet-api/src/modules/user/user.controller.ts
+++ b/apps/recnet-api/src/modules/user/user.controller.ts
@@ -291,7 +291,7 @@ export class UserController {
     @Body() dto: SlackOauthDto
   ): Promise<GetSlackOauthInfoResponse> {
     const { userId } = authUser;
-    return this.userService.installSlack(userId, dto.code);
+    return this.userService.installSlack(userId, dto.redirectUri, dto.code);
   }
 
   @ApiOperation({

--- a/apps/recnet-api/src/modules/user/user.service.ts
+++ b/apps/recnet-api/src/modules/user/user.service.ts
@@ -221,6 +221,7 @@ export class UserService {
 
   public async installSlack(
     userId: string,
+    redirectUri: string,
     code: string
   ): Promise<GetSlackOauthInfoResponse> {
     const user = await this.userRepository.findUserById(userId);
@@ -230,7 +231,11 @@ export class UserService {
         HttpStatus.BAD_REQUEST
       );
     }
-    const oauthInfo = await this.slackService.installApp(userId, code);
+    const oauthInfo = await this.slackService.installApp(
+      userId,
+      redirectUri,
+      code
+    );
     await this.userRepository.updateUserSlackInfo(userId, oauthInfo);
     return {
       workspaceName: oauthInfo.slackWorkspaceName,

--- a/apps/recnet/src/app/api/slack/oauth/callback/route.ts
+++ b/apps/recnet/src/app/api/slack/oauth/callback/route.ts
@@ -2,12 +2,12 @@ import { redirect } from "next/navigation";
 import { type NextRequest } from "next/server";
 
 import { serverClient } from "@recnet/recnet-web/app/_trpc/serverClient";
+import { serverEnv } from "@recnet/recnet-web/serverEnv";
 
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
   const code = searchParams.get("code");
   const errorDesc = searchParams.get("error_description");
-  console.log("req: ", req);
 
   if (!code) {
     redirect(
@@ -17,7 +17,10 @@ export async function GET(req: NextRequest) {
   let isSuccess = true;
   let workspaceName = "";
   try {
-    const data = await serverClient.slackOAuth2FA({ code });
+    const data = await serverClient.slackOAuth2FA({
+      code: code,
+      redirectUri: serverEnv.SLACK_OAUTH_REDIRECT_URI,
+    });
     workspaceName = data.workspaceName;
   } catch (e) {
     console.error("e: ", e);

--- a/apps/recnet/src/server/routers/subscription.ts
+++ b/apps/recnet/src/server/routers/subscription.ts
@@ -34,13 +34,14 @@ export const subscriptionRouter = router({
     .input(postUsersSubscriptionsSlackOauthRequestSchema)
     .output(postUsersSubscriptionsSlackOauthResponseSchema)
     .mutation(async (opts) => {
-      const { code } = opts.input;
+      const { code, redirectUri } = opts.input;
       const { recnetApi } = opts.ctx;
 
       const { data } = await recnetApi.post(
         "/users/subscriptions/slack/oauth",
         {
           code,
+          redirectUri,
         }
       );
       return postUsersSubscriptionsSlackOauthResponseSchema.parse(data);

--- a/libs/recnet-api-model/src/lib/api/user.ts
+++ b/libs/recnet-api-model/src/lib/api/user.ts
@@ -134,6 +134,7 @@ export type PostUsersSubscriptionsResponse = z.infer<
 // POST /users/subscriptions/slack/oauth
 export const postUsersSubscriptionsSlackOauthRequestSchema = z.object({
   code: z.string(),
+  redirectUri: z.string(),
 });
 export type PostUsersSubscriptionsSlackOauthRequest = z.infer<
   typeof postUsersSubscriptionsSlackOauthRequestSchema


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix the issue of `bad_redirect_uri` in staging env. The root cause is that if we specify the redirect_uri in the authorize and redirect stage, we should also pass the redirect_uri with code to access information in our backend service. Otherwise, if we setup multiple redirect URLs for the app, it will always take the first redirect URL and oauth will fail.

Ref: https://api.slack.com/authentication/oauth-v2#asking

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

## TODO

- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
