### PR TITLE
[recnet-api] Fix: change from field of email

### DIFF
--- a/apps/recnet-api/src/modules/email/email.service.ts
+++ b/apps/recnet-api/src/modules/email/email.service.ts
@@ -36,7 +36,7 @@ export class EmailService {
 
     // send email
     const mailOptions = {
-      from: this.nodemailerConfig.user,
+      from: `RecNet<${this.nodemailerConfig.user}>`,
       to: user.email,
       subject: WeeklyDigestSubject(cutoff, this.appConfig.nodeEnv),
       html: render(

--- a/apps/recnet-api/src/modules/subscription/subscription.controller.ts
+++ b/apps/recnet-api/src/modules/subscription/subscription.controller.ts
@@ -59,7 +59,8 @@ export class SubscriptionController {
 
   /* Development only */
   @ApiOperation({
-    summary: "[Dev only] Send weekly digest slack to the designated user.",
+    summary:
+      "[Dev only] Send slack weekly digest slack to the designated user.",
     description: "This endpoint is for development only.",
   })
   @ApiCreatedResponse()
@@ -91,7 +92,8 @@ export class SubscriptionController {
   }
 
   @ApiOperation({
-    summary: "[Dev only] Send weekly digest slack to the designated user.",
+    summary:
+      "[Dev only] Send email weekly digest slack to the designated user.",
     description: "This endpoint is for development only.",
   })
   @ApiCreatedResponse()

--- a/apps/recnet-api/src/modules/subscription/subscription.controller.ts
+++ b/apps/recnet-api/src/modules/subscription/subscription.controller.ts
@@ -19,7 +19,32 @@ import { announcementSchema, recSchema } from "@recnet/recnet-api-model";
 
 import { WeeklyDigestContent } from "./subscription.type";
 
+import { EmailService } from "../email/email.service";
 import { SlackService } from "../slack/slack.service";
+
+function getMockWeeklyDigestData(): WeeklyDigestContent {
+  const getMockRec = (title = 1) =>
+    generateMock(recSchema, {
+      stringMap: {
+        photoUrl: () => "https://avatar.iran.liara.run/public",
+        title: () => `Paper Title ${title}`,
+      },
+    });
+  const announcement = generateMock(announcementSchema, {
+    stringMap: {
+      content: () => "This is a test announcement!",
+    },
+  });
+  return {
+    recs: [getMockRec(), getMockRec(2), getMockRec(3), getMockRec()],
+    numUnusedInviteCodes: 3,
+    latestAnnouncement: {
+      ...announcement,
+      startAt: new Date(announcement.startAt),
+      endAt: new Date(announcement.endAt),
+    },
+  };
+}
 
 @ApiTags("subscriptions")
 @Controller("subscriptions")
@@ -28,6 +53,7 @@ export class SubscriptionController {
     @Inject(AppConfig.KEY)
     private readonly appConfig: ConfigType<typeof AppConfig>,
     private readonly slackService: SlackService,
+    private readonly emailService: EmailService,
     private readonly userRepository: UserRepository
   ) {}
 
@@ -46,7 +72,7 @@ export class SubscriptionController {
     },
   })
   @Post("slack/test")
-  public async testSendingWeeklyDigest(
+  public async testSendingSlackWeeklyDigest(
     @Body("userId") userId: string
   ): Promise<void> {
     if (this.appConfig.nodeEnv === "production") {
@@ -57,34 +83,42 @@ export class SubscriptionController {
       );
     }
 
-    function getMockWeeklyDigestData(): WeeklyDigestContent {
-      const getMockRec = (title = 1) =>
-        generateMock(recSchema, {
-          stringMap: {
-            photoUrl: () => "https://avatar.iran.liara.run/public",
-            title: () => `Paper Title ${title}`,
-          },
-        });
-      const announcement = generateMock(announcementSchema, {
-        stringMap: {
-          content: () => "This is a test announcement!",
-        },
-      });
-      return {
-        recs: [getMockRec(), getMockRec(2), getMockRec(3), getMockRec()],
-        numUnusedInviteCodes: 3,
-        latestAnnouncement: {
-          ...announcement,
-          startAt: new Date(announcement.startAt),
-          endAt: new Date(announcement.endAt),
-        },
-      };
+    const cutoff = getLatestCutOff();
+    const user = await this.userRepository.findUserById(userId);
+    const content = getMockWeeklyDigestData();
+
+    this.slackService.sendWeeklyDigest(user, content, cutoff);
+  }
+
+  @ApiOperation({
+    summary: "[Dev only] Send weekly digest slack to the designated user.",
+    description: "This endpoint is for development only.",
+  })
+  @ApiCreatedResponse()
+  @ApiBody({
+    schema: {
+      properties: {
+        userId: { type: "string" },
+      },
+      required: ["userId"],
+    },
+  })
+  @Post("email/test")
+  public async testSendingEmailWeeklyDigest(
+    @Body("userId") userId: string
+  ): Promise<void> {
+    if (this.appConfig.nodeEnv === "production") {
+      throw new RecnetError(
+        ErrorCode.INTERNAL_SERVER_ERROR,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "This endpoint is only for development"
+      );
     }
 
     const cutoff = getLatestCutOff();
     const user = await this.userRepository.findUserById(userId);
     const content = getMockWeeklyDigestData();
 
-    this.slackService.sendWeeklyDigest(user, content, cutoff);
+    this.emailService.sendWeeklyDigest(user, content, cutoff);
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- The "From" field now is `lil.recnet@gmail.com` and we want it to be `RecNet`
- Misc: add back email test api `POST /subscriptions/email/test`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #247 

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->
use `POST /subscriptions/email/test`

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->

Comparison

![Screenshot 2024-12-04 at 1 48 43 PM](https://github.com/user-attachments/assets/1e867128-a538-46a9-9008-0c054693e8d3)

## TODO

- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
