### PR TITLE
[recnet-api] Remove excessive links in slack weekly digest template

### DIFF
--- a/apps/recnet-api/src/modules/slack/templates/weekly-digest.template.ts
+++ b/apps/recnet-api/src/modules/slack/templates/weekly-digest.template.ts
@@ -32,7 +32,7 @@ export const weeklyDigestSlackTemplate = (
       }),
       ...recs.map((rec) =>
         Blocks.Section({
-          text: `${Md.link(`https://recnet.io/${rec.user.handle}`, rec.user.displayName)}${rec.isSelfRec ? Md.italic("(Self-Rec)") : ""}: ${rec.description} (${Md.link(`https://recnet.io/rec/${rec.id}`, "view")})`,
+          text: `${rec.user.displayName} ${rec.isSelfRec ? Md.italic("(Self-Rec)") : ""}: ${rec.description}`,
         })
       ),
       Blocks.Divider(),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Remove excessive links in slack weekly digest template

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#374 

## Notes

<!-- Other thing to say -->

## Test

<!--- Please describe in detail how you tested your changes locally. -->

## Screenshots (if appropriate):

<!--- Add screenshots of your changes here -->
Before:
![Screenshot 2024-12-07 at 11 06 23 PM](https://github.com/user-attachments/assets/7b8ce8f6-9b05-4a77-966d-5e85b4b7c18f)
Now:

![Screenshot 2024-12-07 at 11 06 36 PM](https://github.com/user-attachments/assets/10321e9e-6a8b-4089-97fb-a8ccb4916079)

## TODO

- [ ] Clear `console.log` or `console.error` for debug usage
- [ ] Update the documentation `recnet-docs` if needed
